### PR TITLE
Reliability fixes, plugin system, URL sketch sharing, tests & CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    name: Lint, test & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Test
+        run: bun test
+
+      - name: Build client bundle
+        run: bun run build

--- a/README.md
+++ b/README.md
@@ -46,3 +46,25 @@ await s0.initVideo("http://localhost:3000/my-video.mp4");
 Supported formats:
 - **Images**: `.jpg`, `.jpeg`, `.png`, `.svg`, `.ico`
 - **Videos**: `.mp4`, `.webm`, `.ogg`, `.avi`, `.mov`
+
+## Sharing Sketches as URLs
+
+Press `Alt/⌥ + U` to copy a link with your current sketch encoded in the URL.
+Opening such a link loads and runs the sketch without touching the recipient's
+saved banks — nothing is persisted unless they explicitly save it.
+
+## Plugins
+
+New features are built as plugins on a small plugin system with an event bus,
+quota-safe storage and error isolation (a broken plugin can't take down a live
+set). See [docs/PLUGINS.md](./docs/PLUGINS.md) for how to write one, and
+`src/client/plugins/` for the built-in examples (URL sketch sharing, audio
+watchdog).
+
+## Development
+
+```bash
+bun run lint   # Biome checks (enforced in CI)
+bun test       # unit tests (enforced in CI)
+bun run build  # build the client bundle
+```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,37 @@
 
 # HYDRACTRL
 
-A wrapper around [hydra](https://hydra.ojack.xyz/) designed for live visual performances.
-Check out the [project page](https://dxviie.github.io/HYDRACTRL/) or go [play around](https://hydractrl.d17e.dev)
+A performance wrapper around [hydra](https://hydra.ojack.xyz/) designed for live visual performances — for the moments where you don't necessarily want to be coding.
+
+**[Project page](https://dxviie.github.io/HYDRACTRL/)** · **[Play around](https://hydractrl.d17e.dev)** · **[Plugin docs](./docs/PLUGINS.md)**
+
+## Features
+
+- **Scene management** — store and recall up to 64 scenes (4 banks × 16 slots) with thumbnail previews
+- **MIDI integration** — built for the Korg nanoPAD2, including its XY pad with a small physics engine for expressive control (mouse works too)
+- **Advanced code editor** — CodeMirror 6 with Hydra syntax highlighting, code completion, multiple themes and error reporting
+- **Setup code tab** — code that runs before each sketch, for audio settings and globals
+- **Audio reactivity** — Hydra's `a.fft` data out of the box, guarded by an audio watchdog that logs dropouts and auto-resumes suspended audio
+- **Built-in Hydra documentation** — always at hand while coding
+- **Breakout view** — send visuals to a second window at a precise size for projections or recordings ([OBS](https://obsproject.com/) and [NDI](https://ndi.video/) work great)
+- **Import/export banks** — save and share entire scene banks as JSON
+- **Share sketches as URLs** — `Alt/⌥ + U` copies a link with your sketch encoded in it
+- **Plugin system** — new features are isolated plugins; write your own (see below)
+
+## Keyboard Shortcuts
+
+| Shortcut | Function |
+| --- | --- |
+| `Ctrl/⌘ + `` ` `` | Toggle UI visibility (works on any keyboard layout) |
+| `Esc` | Bring back the hidden UI |
+| `Ctrl/⌘ + Enter` | Run the current code |
+| `Ctrl/⌘ + S` | Save code to the active slot |
+| `Ctrl/⌘ + Y` | Toggle auto-run |
+| `Alt/⌥ + U` | Copy the current sketch as a shareable URL |
+| `Alt/⌥ + 0-9 / A-F` | Select slot 1-16 (HEX) in the current bank |
+| `Alt/⌥ + ←/→` | Cycle between banks (when no MIDI device is connected) |
+| `Alt/⌥ + X` | Export scene bank |
+| `Alt/⌥ + I` | Import scene bank |
 
 ## Quick Start
 
@@ -19,7 +48,9 @@ bun install
 bun dev
 ```
 
-## Building Standalone Executable
+Then open http://localhost:3000 in your browser.
+
+## Building a Standalone Executable
 
 Create a portable executable that includes all dependencies:
 
@@ -56,10 +87,14 @@ saved banks — nothing is persisted unless they explicitly save it.
 ## Plugins
 
 New features are built as plugins on a small plugin system with an event bus,
-quota-safe storage and error isolation (a broken plugin can't take down a live
-set). See [docs/PLUGINS.md](./docs/PLUGINS.md) for how to write one, and
-`src/client/plugins/` for the built-in examples (URL sketch sharing, audio
-watchdog).
+quota-safe storage and error isolation — a broken plugin can't take down a live
+set. The built-in URL sketch sharing and audio watchdog are the first two
+plugins (see `src/client/plugins/`).
+
+Want to implement your own? **[Read the plugin documentation](./docs/PLUGINS.md)** —
+it covers the plugin shape, the context object you get, and the events you can
+listen to. Plugins can even be registered at runtime from the browser console
+via `window.hydractrl.registerPlugin(...)`.
 
 ## Development
 
@@ -68,3 +103,14 @@ bun run lint   # Biome checks (enforced in CI)
 bun test       # unit tests (enforced in CI)
 bun run build  # build the client bundle
 ```
+
+Contributions are welcome — bug reports and ideas live in
+[GitHub issues](https://github.com/dxviie/HYDRACTRL/issues).
+
+## Credits & License
+
+Built on top of [Hydra](https://hydra.ojack.xyz/) by [Olivia Jack](https://ojack.xyz/),
+with [Bun](https://bun.sh/), [CodeMirror 6](https://codemirror.net/) and the Web MIDI API.
+Made with ❤️ by [D17E](https://www.d17e.dev).
+
+Licensed under the [GNU AGPL v3](./LICENSE).

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,16 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useTemplate": "off",
+        "useSingleVarDeclarator": "off",
+        "noParameterAssign": "off"
+      },
+      "complexity": {
+        "noForEach": "off",
+        "useOptionalChain": "off"
+      }
     }
   },
   "formatter": {

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,103 @@
+# HYDRACTRL Plugin System
+
+HYDRACTRL has a small plugin system so new features can be added without
+touching (or breaking) the core. The two first features built on it are
+URL sketch sharing (`src/client/plugins/UrlSharePlugin.js`) and the audio
+watchdog (`src/client/plugins/AudioWatchdogPlugin.js`) — read them as
+reference implementations.
+
+## Anatomy of a plugin
+
+A plugin is a plain object with an `id` and a `setup` function:
+
+```js
+export function createMyPlugin() {
+  return {
+    id: "my-plugin",              // required, unique
+    name: "My Plugin",            // optional, shown in diagnostics
+    description: "What it does",  // optional
+
+    setup(ctx) {
+      // Wire up your feature here. Runs once when the app initializes.
+      const onKeyDown = (e) => { /* ... */ };
+      document.addEventListener("keydown", onKeyDown);
+
+      // Optionally return an API and/or cleanup:
+      return {
+        api: { doSomething() { /* ... */ } },
+        dispose() {
+          document.removeEventListener("keydown", onKeyDown);
+        },
+      };
+      // (returning just a function is also supported — it's treated as dispose)
+    },
+  };
+}
+```
+
+## The context object (`ctx`)
+
+`setup` receives a shared application context:
+
+| Field | Description |
+| --- | --- |
+| `hydra` | The main hydra-synth instance. |
+| `editor` | The editor proxy (`editor.state.doc.toString()` reads the code, `editor.dispatch({changes: {insert}})` replaces it, `editor.focus()`). |
+| `runCode()` | Run the current editor code on the main and breakout instances. |
+| `events` | App-wide event bus: `on(event, fn)`, `once`, `off`, `emit(event, payload)`. |
+| `storage` | Quota-safe localStorage wrapper: `get`, `set`, `remove`, `getJSON`, `setJSON`, `keys(prefix)`. Never throws. |
+| `notify(msg, {type, duration})` | Toast notifications (`type`: `"info"`, `"success"`, `"error"`). |
+| `getPanels()` | Returns `{ stats, slots, doc, xyPad }` panel objects (may contain `undefined` on mobile). |
+
+## Events you can listen to
+
+| Event | Payload | Emitted when |
+| --- | --- | --- |
+| `plugins:ready` | `{ ids }` | All plugins finished setup. |
+| `plugin:activated` / `plugin:error` / `plugin:removed` | `{ id, ... }` | Plugin lifecycle changes. |
+| `ui:visibility` | `{ visible }` | The UI is hidden/shown (Ctrl/⌘+`, Esc). |
+| `sketch:shared` | `{ url }` | A sketch link was copied (URL share plugin). |
+| `sketch:loaded-from-url` | `{}` | A sketch was loaded from a `#sketch=` URL. |
+| `audio:suspended` / `audio:flatline` / `audio:recovered` | `{ at }` | Audio watchdog state changes. |
+
+Emit your own namespaced events (`"my-plugin:thing-happened"`) to let other
+plugins integrate with yours.
+
+## Registering a plugin
+
+Built-in plugins are registered in `src/client/index.js`:
+
+```js
+pluginHost.register(createMyPlugin());
+```
+
+At runtime (browser console, userscripts, external integrations) you can use
+the public hook:
+
+```js
+window.hydractrl.registerPlugin({
+  id: "console-experiment",
+  setup(ctx) {
+    ctx.events.on("sketch:shared", ({ url }) => console.log("shared:", url));
+  },
+});
+
+window.hydractrl.plugins.list();   // inspect plugin status
+```
+
+Plugins registered after startup are set up immediately.
+
+## Rules of the road
+
+- **Fail safe.** The host isolates plugins: if your `setup` throws, your plugin
+  is disabled and logged but the app keeps running. Don't rely on that —
+  guard your own async callbacks and intervals.
+- **Clean up.** Return a `dispose` that removes listeners and timers, so the
+  plugin can be unregistered cleanly.
+- **Prefer `ctx` over globals.** `window.slotsPanel` & co. still exist for
+  legacy reasons, but new code should use `ctx.getPanels()` / `ctx.storage` /
+  `ctx.events`.
+- **Keep it low-latency.** This is a live-performance tool; avoid heavy work
+  on keystroke or animation paths.
+- **Test the pure parts.** Export pure helpers separately from `setup` and
+  cover them with `bun test` (see `UrlSharePlugin.test.js`).

--- a/docs/index.html
+++ b/docs/index.html
@@ -415,6 +415,25 @@
                             organization and collaboration.</p>
                     </div>
                 </div>
+                <div class="feature-card">
+                    <div>
+                        <i class="fas fa-link"></i>
+                        <h3>Share Sketches as URLs</h3>
+                        <p>Press <code>Alt/⌥ + U</code> to copy a link with your current sketch encoded right in the
+                            URL. Anyone opening it sees your sketch running instantly — without touching their own
+                            saved scenes. Perfect for sharing patches in chats and on socials.</p>
+                    </div>
+                </div>
+                <div class="feature-card">
+                    <div>
+                        <i class="fas fa-puzzle-piece"></i>
+                        <h3>Plugin System</h3>
+                        <p>New features are built as plugins on a small core with an event bus and error isolation —
+                            a broken plugin can't take down a live set. Want to build your own? Check out the
+                            <a href="https://github.com/dxviie/HYDRACTRL/blob/main/docs/PLUGINS.md">plugin
+                                documentation</a>.</p>
+                    </div>
+                </div>
             </div>
         </div> <!-- Closes the container for the overview section -->
     </section> <!-- Closes the overview section -->
@@ -432,7 +451,11 @@
                 <tbody>
                     <tr>
                         <td><code>Ctrl/⌘ + `</code></td>
-                        <td>Toggle UI visibility</td>
+                        <td>Toggle UI visibility (works on any keyboard layout)</td>
+                    </tr>
+                    <tr>
+                        <td><code>Esc</code></td>
+                        <td>Bring back the hidden UI</td>
                     </tr>
                     <tr>
                         <td><code>Ctrl/⌘ + Enter</code></td>
@@ -443,16 +466,20 @@
                         <td>Save code to the active slot</td>
                     </tr>
                     <tr>
-                        <td><code>Ctrl/⌘ + y</code></td>
+                        <td><code>Ctrl/⌘ + Y</code></td>
                         <td>Toggle auto-run</td>
                     </tr>
                     <tr>
-                        <td><code>Alt/⌥ + 1-9</code></td>
-                        <td>Select slots 1-9 in the current bank</td>
+                        <td><code>Alt/⌥ + U</code></td>
+                        <td>Copy the current sketch as a shareable URL</td>
+                    </tr>
+                    <tr>
+                        <td><code>Alt/⌥ + 0-9 / A-F</code></td>
+                        <td>Select slot 1-16 (HEX) in the current bank</td>
                     </tr>
                     <tr>
                         <td><code>Alt/ ⌥ + ←</code> / <code>Alt/⌥ + →</code></td>
-                        <td>Cycle between banks</td>
+                        <td>Cycle between banks (when no MIDI device is connected)</td>
                     </tr>
                     <tr>
                         <td><code>Alt/⌥ + X</code></td>
@@ -496,6 +523,14 @@
                     <h3>Web MIDI API</h3>
                     <p>MIDI integration is implemented using the Web MIDI API, allowing connectivity with hardware
                         controllers for tactile control during performances.</p>
+                </div>
+
+                <div class="credit-item">
+                    <h3>Plugin System</h3>
+                    <p>Features like URL sharing and the audio watchdog are plugins on a small, error-isolated core.
+                        Build your own with the <a
+                            href="https://github.com/dxviie/HYDRACTRL/blob/main/docs/PLUGINS.md">plugin
+                            documentation</a>.</p>
                 </div>
             </div>
         </div>

--- a/src/DocPanel.js
+++ b/src/DocPanel.js
@@ -1,9 +1,9 @@
+import hydraData from "./data/hydra-functions.json" assert { type: "json" };
 /**
  * Documentation Panel Component
  * A draggable panel with Hydra function reference
  */
 import { loadPanelPosition, savePanelPosition } from "./utils/PanelStorage.js";
-import hydraData from "./data/hydra-functions.json" assert { type: "json" };
 
 // Extract categories and functions from the shared JSON resource
 const FUNCTION_CATEGORIES = hydraData.categories;
@@ -32,7 +32,8 @@ export function createDocPanel() {
     panel.style.height = "900px";
   }
 
-  panel.style.backgroundColor = "rgba(var(--color-bg-secondary-rgb), var(--panel-opacity)) !important";
+  panel.style.backgroundColor =
+    "rgba(var(--color-bg-secondary-rgb), var(--panel-opacity)) !important";
   panel.style.borderRadius = "8px";
   panel.style.boxShadow = "0 4px 15px var(--color-panel-shadow)";
   panel.style.backdropFilter = "blur(var(--color-panel-blur))";
@@ -144,7 +145,7 @@ export function createDocPanel() {
 
     // Add example section
     if (funcInfo.example) {
-      const exampleButtonId = `copy-example-btn-${funcName.replace(/\s+/g, '-')}`;
+      const exampleButtonId = `copy-example-btn-${funcName.replace(/\s+/g, "-")}`;
       content += `
         <div class="function-example">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px;">
@@ -162,23 +163,25 @@ export function createDocPanel() {
 
     // Add event listener for the copy button if it exists
     if (funcInfo.example) {
-      const exampleButtonId = `copy-example-btn-${funcName.replace(/\s+/g, '-')}`;
+      const exampleButtonId = `copy-example-btn-${funcName.replace(/\s+/g, "-")}`;
       const copyButton = rightContent.querySelector(`#${exampleButtonId}`);
       if (copyButton) {
-        copyButton.addEventListener('click', (event) => {
+        copyButton.addEventListener("click", (event) => {
           event.stopPropagation(); // Prevent any other click listeners on parent elements
-          navigator.clipboard.writeText(funcInfo.example)
+          navigator.clipboard
+            .writeText(funcInfo.example)
             .then(() => {
               const originalIconHTML = copyButton.innerHTML;
-              copyButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><path fill="none" stroke="var(--color-success, green)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20.829 12.861c.171-.413.171-.938.171-1.986s0-1.573-.171-1.986a2.25 2.25 0 0 0-1.218-1.218c-.413-.171-.938-.171-1.986-.171H11.1c-1.26 0-1.89 0-2.371.245a2.25 2.25 0 0 0-.984.984C7.5 9.209 7.5 9.839 7.5 11.1v6.525c0 1.048 0 1.573.171 1.986c.229.551.667.99 1.218 1.218c.413.171.938.171 1.986.171s1.573 0 1.986-.171m7.968-7.968a2.25 2.25 0 0 1-1.218 1.218c-.413.171-.938.171-1.986.171s-1.573 0-1.986.171a2.25 2.25 0 0 0-1.218 1.218c-.171.413-.171.938-.171 1.986s0 1.573-.171 1.986a2.25 2.25 0 0 1-1.218 1.218m7.968-7.968a11.68 11.68 0 0 1-7.75 7.9l-.218.068M16.5 7.5v-.9c0-1.26 0-1.89-.245-2.371a2.25 2.25 0 0 0-.983-.984C14.79 3 14.16 3 12.9 3H6.6c-1.26 0-1.89 0-2.371.245a2.25 2.25 0 0 0-.984.984C3 4.709 3 5.339 3 6.6v6.3c0 1.26 0 1.89.245 2.371c.216.424.56.768.984.984c.48.245 1.111.245 2.372.245H7.5"/></svg>';
+              copyButton.innerHTML =
+                '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><path fill="none" stroke="var(--color-success, green)" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20.829 12.861c.171-.413.171-.938.171-1.986s0-1.573-.171-1.986a2.25 2.25 0 0 0-1.218-1.218c-.413-.171-.938-.171-1.986-.171H11.1c-1.26 0-1.89 0-2.371.245a2.25 2.25 0 0 0-.984.984C7.5 9.209 7.5 9.839 7.5 11.1v6.525c0 1.048 0 1.573.171 1.986c.229.551.667.99 1.218 1.218c.413.171.938.171 1.986.171s1.573 0 1.986-.171m7.968-7.968a2.25 2.25 0 0 1-1.218 1.218c-.413.171-.938.171-1.986.171s-1.573 0-1.986.171a2.25 2.25 0 0 0-1.218 1.218c-.171.413-.171.938-.171 1.986s0 1.573-.171 1.986a2.25 2.25 0 0 1-1.218 1.218m7.968-7.968a11.68 11.68 0 0 1-7.75 7.9l-.218.068M16.5 7.5v-.9c0-1.26 0-1.89-.245-2.371a2.25 2.25 0 0 0-.983-.984C14.79 3 14.16 3 12.9 3H6.6c-1.26 0-1.89 0-2.371.245a2.25 2.25 0 0 0-.984.984C3 4.709 3 5.339 3 6.6v6.3c0 1.26 0 1.89.245 2.371c.216.424.56.768.984.984c.48.245 1.111.245 2.372.245H7.5"/></svg>';
 
               setTimeout(() => {
                 copyButton.innerHTML = originalIconHTML;
               }, 2000);
             })
-            .catch(err => {
-              console.error('Failed to copy example to clipboard:', err);
-              alert('Failed to copy example. See console for details.');
+            .catch((err) => {
+              console.error("Failed to copy example to clipboard:", err);
+              alert("Failed to copy example. See console for details.");
             });
         });
       }
@@ -194,7 +197,7 @@ export function createDocPanel() {
   functionTagsContainer.style.alignItems = "center";
 
   // Create function list by categories
-  Object.keys(FUNCTION_CATEGORIES).forEach(catKey => {
+  Object.keys(FUNCTION_CATEGORIES).forEach((catKey) => {
     const category = FUNCTION_CATEGORIES[catKey];
 
     // Create category heading
@@ -208,7 +211,7 @@ export function createDocPanel() {
 
     functionTagsContainer.appendChild(categoryHeading);
 
-    category.functions.forEach(funcName => {
+    category.functions.forEach((funcName) => {
       // Create tag-like container for each function
       const funcTag = document.createElement("div");
       funcTag.textContent = funcName;
@@ -226,7 +229,7 @@ export function createDocPanel() {
       funcTag.addEventListener("mouseenter", () => {
         funcTag.style.backgroundColor = `${category.color}40`; // 25% opacity on hover
         funcTag.style.transform = "translateY(-1px)";
-        funcTag.style.boxShadow = `0 2px 4px rgba(0,0,0,0.1)`;
+        funcTag.style.boxShadow = "0 2px 4px rgba(0,0,0,0.1)";
       });
 
       funcTag.addEventListener("mouseleave", () => {
@@ -242,7 +245,7 @@ export function createDocPanel() {
         // Clear previous selection styling
         if (selectedFunction) {
           const tags = functionTagsContainer.querySelectorAll("div");
-          tags.forEach(tag => {
+          tags.forEach((tag) => {
             if (tag.textContent === selectedFunction) {
               tag.style.backgroundColor = `${category.color}20`; // Reset background
               tag.style.transform = "translateY(0)";
@@ -256,7 +259,7 @@ export function createDocPanel() {
         selectedFunction = funcName;
         funcTag.style.backgroundColor = `${category.color}40`; // 25% opacity for selected
         funcTag.style.fontWeight = "bold";
-        funcTag.style.boxShadow = `0 2px 4px rgba(0,0,0,0.15)`;
+        funcTag.style.boxShadow = "0 2px 4px rgba(0,0,0,0.15)";
 
         // Show function details
         showFunctionDetails(funcName);
@@ -280,7 +283,6 @@ export function createDocPanel() {
   // Add columns to the content container
   contentContainer.appendChild(rightContent);
   contentContainer.appendChild(leftSidebar);
-
 
   // Add content container to panel
   panel.appendChild(contentContainer);
@@ -320,10 +322,10 @@ export function createDocPanel() {
 
     // Save the new dimensions
     savePanelPosition("doc-panel", {
-      left: parseInt(panel.style.left),
-      top: parseInt(panel.style.top),
-      width: parseInt(panel.style.width),
-      height: parseInt(panel.style.height)
+      left: Number.parseInt(panel.style.left),
+      top: Number.parseInt(panel.style.top),
+      width: Number.parseInt(panel.style.width),
+      height: Number.parseInt(panel.style.height),
     });
   });
 
@@ -348,8 +350,8 @@ export function createDocPanel() {
   document.addEventListener("mousemove", (e) => {
     if (!isDragging) return;
 
-    panel.style.left = (e.clientX - offsetX) + "px";
-    panel.style.top = (e.clientY - offsetY) + "px";
+    panel.style.left = e.clientX - offsetX + "px";
+    panel.style.top = e.clientY - offsetY + "px";
   });
 
   document.addEventListener("mouseup", () => {
@@ -359,10 +361,10 @@ export function createDocPanel() {
 
       // Save the new position
       savePanelPosition("doc-panel", {
-        left: parseInt(panel.style.left),
-        top: parseInt(panel.style.top),
-        width: parseInt(panel.style.width),
-        height: parseInt(panel.style.height)
+        left: Number.parseInt(panel.style.left),
+        top: Number.parseInt(panel.style.top),
+        width: Number.parseInt(panel.style.width),
+        height: Number.parseInt(panel.style.height),
       });
     }
   });
@@ -383,6 +385,6 @@ export function createDocPanel() {
     hide: () => {
       panel.style.display = "none";
     },
-    isVisible: () => panel.style.display !== "none"
+    isVisible: () => panel.style.display !== "none",
   };
 }

--- a/src/MidiManager.js
+++ b/src/MidiManager.js
@@ -8,7 +8,7 @@ let midiAccess = null;
 let activeDevice = null;
 let isConnected = false;
 let xyPadPanel = null;
-let xyPadValues = { x: 0, y: 0 };
+const xyPadValues = { x: 0, y: 0 };
 
 export function createMidiManager(slotsPanel) {
   // Initialize global XY pad values
@@ -63,11 +63,9 @@ export function createMidiManager(slotsPanel) {
 
     console.log(
       "MIDI Debug Info: If your scene buttons aren't recognized, " +
-      "press them and check the console log to see their MIDI messages. " +
-      "Then you can add them to the supported patterns.",
+        "press them and check the console log to see their MIDI messages. " +
+        "Then you can add them to the supported patterns.",
     );
-
-
 
     return true;
   }
@@ -110,7 +108,7 @@ export function createMidiManager(slotsPanel) {
     isConnected = true;
 
     // Check if it's a nanoPAD or similar
-    isNanoPad = device.name.toLowerCase().includes('nanopad');
+    isNanoPad = device.name.toLowerCase().includes("nanopad");
     showMidiStatus(`Connected to ${device.name}`, false);
 
     console.log(`MIDI connected: ${activeDevice.name}`);
@@ -192,7 +190,7 @@ export function createMidiManager(slotsPanel) {
         }
 
         // Update XY pad panel if available
-        if (xyPadPanel && typeof xyPadPanel.updateFromMIDI === 'function') {
+        if (xyPadPanel && typeof xyPadPanel.updateFromMIDI === "function") {
           xyPadPanel.updateFromMIDI(xyPadValues.x, xyPadValues.y);
         }
 
@@ -249,7 +247,7 @@ export function createMidiManager(slotsPanel) {
             lastBankChange = now;
             handlePossibleSceneChange(sceneNumber);
           } else {
-            console.debug(`Throttling nanoPAD2 scene change to prevent XY pad interference`);
+            console.debug("Throttling nanoPAD2 scene change to prevent XY pad interference");
           }
         }
       }
@@ -627,14 +625,14 @@ export function createMidiManager(slotsPanel) {
     startLearnMode: (callback) => {
       isLearning = true;
       learnCallback = callback;
-      showMidiStatus('Press a pad to map it...', false);
+      showMidiStatus("Press a pad to map it...", false);
     },
 
     // Cancel MIDI learn mode
     cancelLearnMode: () => {
       isLearning = false;
       learnCallback = null;
-      showMidiStatus('MIDI learn cancelled', false);
+      showMidiStatus("MIDI learn cancelled", false);
     },
 
     // Check if we're in learn mode
@@ -644,7 +642,7 @@ export function createMidiManager(slotsPanel) {
     setXYPadPanel: (panel) => {
       xyPadPanel = panel;
       // Initialize with current values if they exist
-      if (panel && typeof panel.updateFromMIDI === 'function' && xyPadValues.x !== undefined) {
+      if (panel && typeof panel.updateFromMIDI === "function" && xyPadValues.x !== undefined) {
         panel.updateFromMIDI(xyPadValues.x, xyPadValues.y);
       }
     },

--- a/src/SlotsPanel.js
+++ b/src/SlotsPanel.js
@@ -91,7 +91,7 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
 
     // Add hover effect
     dot.addEventListener("mouseover", () => {
-      const bank = parseInt(dot.dataset.bank);
+      const bank = Number.parseInt(dot.dataset.bank);
       if (bank !== currentBank) {
         // Highlight with a brighter version of its current color
         if (bankHasContent(bank)) {
@@ -159,8 +159,9 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
   const shortcutsLabel = document.createElement("div");
   shortcutsLabel.className = "shortcut";
   shortcutsLabel.style.marginLeft = "4px";
-  shortcutsLabel.innerHTML = "<span style='font-size: 10px; color: var(--color-text-secondary);'>Alt/⌥ + ←/→</span>";
-  
+  shortcutsLabel.innerHTML =
+    "<span style='font-size: 10px; color: var(--color-text-secondary);'>Alt/⌥ + ←/→</span>";
+
   dotsContainer.appendChild(shortcutsLabel);
   dotsContainer.appendChild(diceBtn);
 
@@ -185,7 +186,8 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
   exportBtn.style.cursor = "pointer";
   exportBtn.style.color = "white";
   exportBtn.style.fontWeight = "bold";
-  exportBtn.innerHTML = "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><g fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M12 16.5v-9M8.5 11L12 7.5l3.5 3.5'/><path d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6z'/></g></svg>"
+  exportBtn.innerHTML =
+    "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><g fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M12 16.5v-9M8.5 11L12 7.5l3.5 3.5'/><path d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6z'/></g></svg>";
   // Create import button
   const importBtn = document.createElement("div");
   importBtn.className = "slots-import";
@@ -199,7 +201,8 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
   importBtn.style.cursor = "pointer";
   importBtn.style.color = "white";
   importBtn.style.fontWeight = "bold";
-  importBtn.innerHTML = "<svg xmlns='http://www.w3.org/2000/svg' style='transform: rotate(180deg);' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><g fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M12 16.5v-9M8.5 11L12 7.5l3.5 3.5'/><path d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6z'/></g></svg>"
+  importBtn.innerHTML =
+    "<svg xmlns='http://www.w3.org/2000/svg' style='transform: rotate(180deg);' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><g fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M12 16.5v-9M8.5 11L12 7.5l3.5 3.5'/><path d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6z'/></g></svg>";
 
   // Add icons to container
   iconsContainer.appendChild(exportBtn);
@@ -223,7 +226,8 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
   clearBtn.style.display = "flex";
   clearBtn.style.alignItems = "center";
   clearBtn.style.justifyContent = "center";
-  clearBtn.innerHTML = "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><path fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6zM15 9l-6 6m0-6l6 6'/></svg>"
+  clearBtn.innerHTML =
+    "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><path fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6zM15 9l-6 6m0-6l6 6'/></svg>";
 
   // Add hover effect
   clearBtn.addEventListener("mouseover", () => {
@@ -290,7 +294,9 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
     index.style.right = "4px";
     index.style.fontSize = "12px";
     index.style.fontWeight = "bold";
-    index.innerHTML = "<span style='font-size: 8px; margin-right: 2px;'>Alt/⌥ +</span>" + i.toString(16).toUpperCase();
+    index.innerHTML =
+      "<span style='font-size: 8px; margin-right: 2px;'>Alt/⌥ +</span>" +
+      i.toString(16).toUpperCase();
 
     // Thumbnail container for preview images
     const thumbnail = document.createElement("div");
@@ -376,7 +382,7 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
     const prevStorageKey = getStorageKey(currentBank, activeSlotIndex);
     const prevHasCode = localStorage.getItem(prevStorageKey);
     const prevThumbnail = localStorage.getItem(`${prevStorageKey}-thumbnail`);
-    
+
     if (prevThumbnail) {
       // Has thumbnail, use normal border
       slotElements[activeSlotIndex].style.border = "1px solid var(--color-bg-tertiary)";
@@ -397,7 +403,7 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
     // Load code from storage if requested
     if (loadContent) {
       await loadSlot(activeSlotIndex);
-      
+
       // Additional overlay update for mobile (in case the loadSlot update didn't work)
       if (window.codeOverlay) {
         setTimeout(() => {
@@ -487,7 +493,7 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
           mainTabButton.click();
         }
       }
-      
+
       // Load code into editor (this will be main code only)
       editor.dispatch({
         changes: { from: 0, to: editor.state.doc.length, insert: savedCode },
@@ -514,7 +520,7 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
     try {
       // Calculate total localStorage size
       let totalSize = 0;
-      let thumbnailKeys = [];
+      const thumbnailKeys = [];
 
       // Iterate through all localStorage keys
       for (let i = 0; i < localStorage.length; i++) {
@@ -526,11 +532,11 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
         totalSize += size;
 
         // Collect thumbnail keys for potential purging
-        if (key.includes('-thumbnail')) {
+        if (key.includes("-thumbnail")) {
           thumbnailKeys.push({
             key,
             size,
-            timeStamp: Number(localStorage.getItem(key + '-timestamp') || Date.now())
+            timeStamp: Number(localStorage.getItem(key + "-timestamp") || Date.now()),
           });
         }
       }
@@ -541,7 +547,9 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
       // If we're approaching the 5MB limit, start purging thumbnails
       // Starting with oldest ones first
       if (totalSizeMB > 4.5) {
-        console.warn(`LocalStorage usage high (${totalSizeMB.toFixed(2)}MB). Purging old thumbnails.`);
+        console.warn(
+          `LocalStorage usage high (${totalSizeMB.toFixed(2)}MB). Purging old thumbnails.`,
+        );
 
         // Sort thumbnails by timestamp (oldest first)
         thumbnailKeys.sort((a, b) => a.timeStamp - b.timeStamp);
@@ -549,7 +557,7 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
         // Purge thumbnails until we get below 4MB
         for (const item of thumbnailKeys) {
           localStorage.removeItem(item.key);
-          localStorage.removeItem(item.key + '-timestamp');
+          localStorage.removeItem(item.key + "-timestamp");
 
           totalSize -= item.size;
           const newSizeMB = totalSize / (1024 * 1024);
@@ -602,18 +610,33 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
           ctx.imageSmoothingQuality = "high";
 
           // Draw the main canvas scaled down to our tiny canvas
-          ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height,
-            0, 0, thumbnailSize, thumbnailSize);
+          ctx.drawImage(
+            canvas,
+            0,
+            0,
+            canvas.width,
+            canvas.height,
+            0,
+            0,
+            thumbnailSize,
+            thumbnailSize,
+          );
 
           // Create thumbnail image from the small canvas with very low quality
           const thumbnail = tmpCanvas.toDataURL("image/jpeg", 0.4); // Use JPEG with 40% quality for smaller size
 
           // Save thumbnail to localStorage with bank and slot index
           // We use the target indices here to ensure we're saving to the correct slot
-          localStorage.setItem(`${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail`, thumbnail);
+          localStorage.setItem(
+            `${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail`,
+            thumbnail,
+          );
 
           // Store timestamp for age-based purging
-          localStorage.setItem(`${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail-timestamp`, Date.now());
+          localStorage.setItem(
+            `${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail-timestamp`,
+            Date.now(),
+          );
 
           // Update the slot thumbnail if the target bank is visible
           if (targetBankIndex === currentBank) {
@@ -691,10 +714,16 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
   // Function to clear all slots
   function clearAllSlots() {
     // Create confirmation options
-    const options = ["Clear Current Bank", "Clear All Banks", "Clear All Thumbnails Only", "Cancel"];
+    const options = [
+      "Clear Current Bank",
+      "Clear All Banks",
+      "Clear All Thumbnails Only",
+      "Cancel",
+    ];
 
     // Show dialog with options
-    const message = "What would you like to clear?\n\n" +
+    const message =
+      "What would you like to clear?\n\n" +
       "1. Clear Current Bank - Removes all slots in the current bank\n" +
       "2. Clear All Banks - Removes all slots in all banks\n" +
       "3. Clear All Thumbnails Only - Keeps code but removes all thumbnails to save space";
@@ -712,7 +741,7 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
 
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
-        if (key && key.includes('-thumbnail')) {
+        if (key && key.includes("-thumbnail")) {
           localStorage.removeItem(key);
           thumbnailCount++;
         }
@@ -839,8 +868,8 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
   // Add window resize event listener to ensure panel stays on screen
   window.addEventListener("resize", () => {
     // Get current panel position
-    const left = parseInt(panel.style.left || "0");
-    const top = parseInt(panel.style.top || "0");
+    const left = Number.parseInt(panel.style.left || "0");
+    const top = Number.parseInt(panel.style.top || "0");
 
     // Ensure the panel stays within the viewport bounds
     const minVisiblePart = 100; // Minimum visible part in pixels
@@ -977,22 +1006,22 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
     try {
       // Generate random file number (0-29 for 30 files)
       const randomFileNumber = Math.floor(Math.random() * 30);
-      const fileName = `bank-${randomFileNumber.toString().padStart(2, '0')}.json`;
+      const fileName = `bank-${randomFileNumber.toString().padStart(2, "0")}.json`;
       const fileUrl = `/assets/banks/random/${fileName}`;
 
       console.log(`Loading random scenes from: ${fileName}`);
 
       // Fetch the random JSON file
       const response = await fetch(fileUrl);
-      
+
       if (!response.ok) {
         console.warn(`Failed to load ${fileName}, status: ${response.status}`);
         // Try a few more random files if the first one fails
         for (let attempts = 0; attempts < 5; attempts++) {
           const retryFileNumber = Math.floor(Math.random() * 30);
-          const retryFileName = `bank-${retryFileNumber.toString().padStart(2, '0')}.json`;
+          const retryFileName = `bank-${retryFileNumber.toString().padStart(2, "0")}.json`;
           const retryFileUrl = `/assets/banks/random/${retryFileName}`;
-          
+
           const retryResponse = await fetch(retryFileUrl);
           if (retryResponse.ok) {
             const scenesData = await retryResponse.json();
@@ -1000,15 +1029,14 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
             return;
           }
         }
-        throw new Error(`Could not load any random scenes after multiple attempts`);
+        throw new Error("Could not load any random scenes after multiple attempts");
       }
 
       const scenesData = await response.json();
       await processRandomScenes(scenesData, fileName);
-
     } catch (error) {
       console.error("Error loading random scenes:", error);
-      
+
       // Show error notification
       const notification = document.createElement("div");
       notification.className = "saved-notification";
@@ -1309,11 +1337,11 @@ function makeDraggable(element, handle, panelId) {
       const rect = element.getBoundingClientRect();
 
       // Calculate position based on right alignment
-      const rightOffset = parseInt(element.style.right || "0");
+      const rightOffset = Number.parseInt(element.style.right || "0");
       currentX = window.innerWidth - rect.width - rightOffset;
 
       // Calculate position based on bottom alignment
-      const bottomOffset = parseInt(element.style.bottom || "0");
+      const bottomOffset = Number.parseInt(element.style.bottom || "0");
       currentY = window.innerHeight - rect.height - bottomOffset;
 
       // Set explicit left and top position
@@ -1325,8 +1353,8 @@ function makeDraggable(element, handle, panelId) {
       element.style.right = "";
     } else {
       // Already positioned by left/top (from saved position or default)
-      currentX = parseInt(element.style.left || "0");
-      currentY = parseInt(element.style.top || "0");
+      currentX = Number.parseInt(element.style.left || "0");
+      currentY = Number.parseInt(element.style.top || "0");
     }
 
     // Ensure the panel stays within the viewport bounds
@@ -1376,8 +1404,8 @@ function makeDraggable(element, handle, panelId) {
     initialY = e.clientY;
 
     // Get current element position from inline style
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Start dragging
     isDragging = true;
@@ -1416,8 +1444,8 @@ function makeDraggable(element, handle, panelId) {
     if (!isDragging) return;
 
     // Update current position with final offsets
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Save position to localStorage if we have a panelId
     if (panelId) {

--- a/src/SlotsPanel.js
+++ b/src/SlotsPanel.js
@@ -4,7 +4,7 @@
  */
 import { loadPanelPosition, savePanelPosition } from "./utils/PanelStorage.js";
 
-export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false) {
+export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false, options = {}) {
   // Load saved position or use defaults
   const savedPosition = loadPanelPosition("slots-panel");
 
@@ -625,18 +625,24 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
           // Create thumbnail image from the small canvas with very low quality
           const thumbnail = tmpCanvas.toDataURL("image/jpeg", 0.4); // Use JPEG with 40% quality for smaller size
 
-          // Save thumbnail to localStorage with bank and slot index
-          // We use the target indices here to ensure we're saving to the correct slot
-          localStorage.setItem(
-            `${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail`,
-            thumbnail,
-          );
+          // Save thumbnail to localStorage with bank and slot index.
+          // We use the target indices to ensure we save to the correct slot.
+          // This runs in an async callback, so the outer try/catch can't see a
+          // QuotaExceededError — guard it here (thumbnails are the main quota eater).
+          try {
+            localStorage.setItem(
+              `${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail`,
+              thumbnail,
+            );
 
-          // Store timestamp for age-based purging
-          localStorage.setItem(
-            `${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail-timestamp`,
-            Date.now(),
-          );
+            // Store timestamp for age-based purging
+            localStorage.setItem(
+              `${getStorageKey(targetBankIndex, targetSlotIndex)}-thumbnail-timestamp`,
+              Date.now(),
+            );
+          } catch (storageError) {
+            console.warn("Could not save slot thumbnail (storage full?):", storageError);
+          }
 
           // Update the slot thumbnail if the target bank is visible
           if (targetBankIndex === currentBank) {
@@ -887,8 +893,16 @@ export function createSlotsPanel(editor, hydra, runCode, mobilePosition = false)
     }
   });
 
-  // Load all saved slots
-  loadAllSlots();
+  // Load all saved slots. When the app was opened with a sketch in the URL
+  // (#sketch=...), keep the editor content instead of loading slot 0 into it.
+  if (options.keepEditorContent) {
+    title.textContent = `SCENE ${currentBank + 1}`;
+    loadAllSlotsForCurrentBank();
+    updateBankDots();
+    setActiveSlot(0, false);
+  } else {
+    loadAllSlots();
+  }
 
   // Flash the active bank dot for visual feedback
   function flashActiveBankDot(bankIndex) {

--- a/src/StatsPanel.js
+++ b/src/StatsPanel.js
@@ -26,14 +26,15 @@ export function createStatsPanel() {
 
   // Load saved opacity or use default
   const panelOpacity = localStorage.getItem("hydractrl-panel-opacity") || "90";
-  const opacityDecimal = parseInt(panelOpacity) / 100;
+  const opacityDecimal = Number.parseInt(panelOpacity) / 100;
 
   // Add panel opacity CSS variable if it doesn't exist
-  if (!document.documentElement.style.getPropertyValue('--panel-opacity')) {
-    document.documentElement.style.setProperty('--panel-opacity', opacityDecimal);
+  if (!document.documentElement.style.getPropertyValue("--panel-opacity")) {
+    document.documentElement.style.setProperty("--panel-opacity", opacityDecimal);
   }
 
-  panel.style.backgroundColor = "rgba(var(--color-bg-secondary-rgb), var(--panel-opacity)) !important";
+  panel.style.backgroundColor =
+    "rgba(var(--color-bg-secondary-rgb), var(--panel-opacity)) !important";
   panel.style.borderRadius = "8px";
   panel.style.boxShadow = "0 4px 15px var(--color-panel-shadow)";
   panel.style.backdropFilter = "blur(var(--color-panel-blur))";
@@ -83,7 +84,8 @@ export function createStatsPanel() {
   docsButton.style.justifyContent = "center";
   docsButton.style.transition = "all 0.2s ease";
   docsButton.title = "Hydra Functions Reference";
-  docsButton.innerHTML = "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><path fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='3.5' d='M12 9.8V20m0-10.2c0-1.704.107-3.584-1.638-4.473C9.72 5 8.88 5 7.2 5H4.6C3.364 5 3 5.437 3 6.6v8.8c0 .568-.036 1.195.546 1.491c.214.109.493.109 1.052.109H7.43c2.377 0 3.26 1.036 4.569 3m0-10.2c0-1.704-.108-3.584 1.638-4.473C14.279 5 15.12 5 16.8 5h2.6c1.235 0 1.6.436 1.6 1.6v8.8c0 .567.035 1.195-.546 1.491c-.213.109-.493.109-1.052.109h-2.833c-2.377 0-3.26 1.036-4.57 3'/></svg>";
+  docsButton.innerHTML =
+    "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><path fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='3.5' d='M12 9.8V20m0-10.2c0-1.704.107-3.584-1.638-4.473C9.72 5 8.88 5 7.2 5H4.6C3.364 5 3 5.437 3 6.6v8.8c0 .568-.036 1.195.546 1.491c.214.109.493.109 1.052.109H7.43c2.377 0 3.26 1.036 4.569 3m0-10.2c0-1.704-.108-3.584 1.638-4.473C14.279 5 15.12 5 16.8 5h2.6c1.235 0 1.6.436 1.6 1.6v8.8c0 .567.035 1.195-.546 1.491c-.213.109-.493.109-1.052.109h-2.833c-2.377 0-3.26 1.036-4.57 3'/></svg>";
   docsButton.style.opacity = "0.7";
 
   docsButton.addEventListener("mouseenter", () => {
@@ -172,8 +174,8 @@ export function createStatsPanel() {
   xyPadButton.textContent = "Show XY Pad";
 
   // Set initial button text based on localStorage
-  const xyPadVisible = localStorage.getItem('hydractrl-xy-pad-visible') === 'true';
-  xyPadButton.textContent = xyPadVisible ? 'Hide XY Pad' : 'Show XY Pad';
+  const xyPadVisible = localStorage.getItem("hydractrl-xy-pad-visible") === "true";
+  xyPadButton.textContent = xyPadVisible ? "Hide XY Pad" : "Show XY Pad";
 
   xyPadButton.addEventListener("click", () => {
     const xyPadPanelElement = document.querySelector(".xy-pad-panel");
@@ -184,8 +186,8 @@ export function createStatsPanel() {
     xyPadPanelElement.style.visibility = newVisible ? "visible" : "hidden";
 
     // Update localStorage and button text
-    localStorage.setItem('hydractrl-xy-pad-visible', newVisible);
-    xyPadButton.textContent = newVisible ? 'Hide XY Pad' : 'Show XY Pad';
+    localStorage.setItem("hydractrl-xy-pad-visible", newVisible);
+    xyPadButton.textContent = newVisible ? "Hide XY Pad" : "Show XY Pad";
   });
 
   // Create MIDI mapping display
@@ -267,7 +269,7 @@ export function createStatsPanel() {
       bgTertiary: "rgba(60, 60, 60, 0.7)",
       textPrimary: "#f5f5f5",
       textSecondary: "#aaa",
-      className: ""
+      className: "",
     },
     {
       name: "light",
@@ -277,7 +279,7 @@ export function createStatsPanel() {
       bgTertiary: "rgba(200, 200, 200, 0.8)",
       textPrimary: "#333333",
       textSecondary: "#666666",
-      className: "theme-light"
+      className: "theme-light",
     },
     {
       name: "dark",
@@ -287,7 +289,7 @@ export function createStatsPanel() {
       bgTertiary: "rgba(35, 35, 35, 0.8)",
       textPrimary: "#ffffff",
       textSecondary: "#cccccc",
-      className: "theme-dark"
+      className: "theme-dark",
     },
     {
       name: "neon-eighties",
@@ -307,7 +309,7 @@ export function createStatsPanel() {
       bgTertiary: "rgba(255, 215, 0, 0.7)",
       textPrimary: "#333333",
       textSecondary: "#222222",
-      className: "theme-nineties-pop"
+      className: "theme-nineties-pop",
     },
   ];
 
@@ -374,11 +376,11 @@ export function createStatsPanel() {
 
       // Get the current opacity value
       const currentOpacity = localStorage.getItem("hydractrl-panel-opacity") || "90";
-      const opacityDecimal = parseInt(currentOpacity) / 100;
+      const opacityDecimal = Number.parseInt(currentOpacity) / 100;
 
       // Re-apply the opacity to all panels with the new theme colors
       setTimeout(() => {
-        applyPanelOpacity(parseInt(currentOpacity));
+        applyPanelOpacity(Number.parseInt(currentOpacity));
       }, 50);
     });
   });
@@ -432,13 +434,13 @@ export function createStatsPanel() {
     const opacityDecimal = opacity / 100;
 
     // Apply to CSS variables using custom property
-    document.documentElement.style.setProperty('--panel-opacity', opacityDecimal);
+    document.documentElement.style.setProperty("--panel-opacity", opacityDecimal);
 
     // Add or update style element for global panel styling
-    let styleEl = document.getElementById('panel-opacity-styles');
+    let styleEl = document.getElementById("panel-opacity-styles");
     if (!styleEl) {
-      styleEl = document.createElement('style');
-      styleEl.id = 'panel-opacity-styles';
+      styleEl = document.createElement("style");
+      styleEl.id = "panel-opacity-styles";
       document.head.appendChild(styleEl);
     }
 
@@ -457,15 +459,15 @@ export function createStatsPanel() {
   }
 
   // Apply initial opacity
-  applyPanelOpacity(parseInt(savedOpacity));
+  applyPanelOpacity(Number.parseInt(savedOpacity));
 
   // Function to update range slider progress visualization
   function updateRangeProgress(slider) {
-    const min = parseInt(slider.min);
-    const max = parseInt(slider.max);
-    const val = parseInt(slider.value);
+    const min = Number.parseInt(slider.min);
+    const max = Number.parseInt(slider.max);
+    const val = Number.parseInt(slider.value);
     const percentage = ((val - min) * 100) / (max - min);
-    slider.style.setProperty('--range-progress', `${percentage}%`);
+    slider.style.setProperty("--range-progress", `${percentage}%`);
   }
 
   // Set initial progress visualization
@@ -480,7 +482,7 @@ export function createStatsPanel() {
     updateRangeProgress(opacitySlider);
 
     // Apply the opacity
-    applyPanelOpacity(parseInt(opacity));
+    applyPanelOpacity(Number.parseInt(opacity));
 
     // Save to localStorage
     localStorage.setItem("hydractrl-panel-opacity", opacity);
@@ -553,7 +555,7 @@ export function createStatsPanel() {
   slotSizeSlider.min = "40";
   slotSizeSlider.max = "100";
   slotSizeSlider.step = "5";
-  
+
   // Load saved slot size or use default (smallest size)
   const savedSlotSize = localStorage.getItem("hydractrl-slot-size") || "40";
   slotSizeSlider.value = savedSlotSize;
@@ -572,13 +574,13 @@ export function createStatsPanel() {
   // Function to update slot sizes in SlotsPanel
   function updateSlotSizes(size) {
     // Update CSS custom property for slot size
-    document.documentElement.style.setProperty('--slot-size', size + 'px');
-    
+    document.documentElement.style.setProperty("--slot-size", size + "px");
+
     // Apply to all slot elements directly
-    const slotElements = document.querySelectorAll('.slot');
-    slotElements.forEach(slot => {
-      slot.style.height = size + 'px';
-      slot.style.width = size + 'px';
+    const slotElements = document.querySelectorAll(".slot");
+    slotElements.forEach((slot) => {
+      slot.style.height = size + "px";
+      slot.style.width = size + "px";
     });
 
     // Save to localStorage
@@ -589,11 +591,11 @@ export function createStatsPanel() {
   slotSizeSlider.addEventListener("input", () => {
     const size = slotSizeSlider.value;
     slotSizeValue.textContent = size + "px";
-    updateSlotSizes(parseInt(size));
+    updateSlotSizes(Number.parseInt(size));
   });
 
   // Apply initial slot size
-  updateSlotSizes(parseInt(savedSlotSize));
+  updateSlotSizes(Number.parseInt(savedSlotSize));
 
   // Add elements to slider container
   slotSizeSliderContainer.appendChild(slotSizeSlider);
@@ -690,7 +692,7 @@ export function createStatsPanel() {
   selectedSizeIndicator.textContent = "No size selected";
 
   // Create a variable to track the selected size
-  let selectedSize = null;
+  const selectedSize = null;
 
   sizes.forEach((size) => {
     const sizeButton = document.createElement("button");
@@ -745,7 +747,6 @@ export function createStatsPanel() {
   fpsValue.style.fontWeight = "bold";
   fpsValue.style.color = "white";
   fpsValue.textContent = "0";
-
 
   // Detailed metrics
   const details = document.createElement("div");
@@ -832,12 +833,14 @@ export function createStatsPanel() {
 
   // Attribution text with links
   const attributionText = document.createElement("div");
-  attributionText.innerHTML = 'made with <span style="color:var(--color-accent-primary);">♥</span> by <a href="https://d17e.dev" target="_blank" style="color:inherit;text-decoration:underline">D17E</a><br>based on <a href="https://hydra.ojack.xyz" target="_blank" style="color:inherit;text-decoration:underline">hydra</a> by <a href="https://www.ojack.xyz" target="_blank" style="color:inherit;text-decoration:underline">Olivia Jack</a>';
+  attributionText.innerHTML =
+    'made with <span style="color:var(--color-accent-primary);">♥</span> by <a href="https://d17e.dev" target="_blank" style="color:inherit;text-decoration:underline">D17E</a><br>based on <a href="https://hydra.ojack.xyz" target="_blank" style="color:inherit;text-decoration:underline">hydra</a> by <a href="https://www.ojack.xyz" target="_blank" style="color:inherit;text-decoration:underline">Olivia Jack</a>';
   attributionText.style.lineHeight = "1.5";
 
   // Info icon button
   const infoButton = document.createElement("button");
-  infoButton.innerHTML = "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><g fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6z'/><path d='M12 16v-5h-.5m0 5h1M12 8.5V8'/></g></svg>";
+  infoButton.innerHTML =
+    "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><!-- Icon from Myna UI Icons by Praveen Juge - https://github.com/praveenjuge/mynaui-icons/blob/main/LICENSE --><g fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M3 9.4c0-2.24 0-3.36.436-4.216a4 4 0 0 1 1.748-1.748C6.04 3 7.16 3 9.4 3h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C21 6.04 21 7.16 21 9.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C17.96 21 16.84 21 14.6 21H9.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C3 17.96 3 16.84 3 14.6z'/><path d='M12 16v-5h-.5m0 5h1M12 8.5V8'/></g></svg>";
   infoButton.style.background = "none";
   infoButton.style.width = "32px";
   infoButton.style.height = "32px";
@@ -853,13 +856,13 @@ export function createStatsPanel() {
   // Add click event to show info panel
   infoButton.addEventListener("click", (e) => {
     e.stopPropagation(); // Stop event from bubbling up to document
-    
+
     // Check if info panel is already visible
     const existingPanel = document.getElementById("info-panel");
     if (existingPanel && existingPanel.style.display !== "none") {
       return; // Don't show panel if it's already visible
     }
-    
+
     if (window.showInfoPanel) {
       window.showInfoPanel();
     } else {
@@ -926,8 +929,8 @@ export function createStatsPanel() {
   // Add window resize event listener to ensure panel stays on screen
   window.addEventListener("resize", () => {
     // Get current panel position
-    const left = parseInt(panel.style.left || "0");
-    const top = parseInt(panel.style.top || "0");
+    const left = Number.parseInt(panel.style.left || "0");
+    const top = Number.parseInt(panel.style.top || "0");
 
     // Ensure the panel stays within the viewport bounds
     const minVisiblePart = 100; // Minimum visible part in pixels
@@ -968,7 +971,7 @@ export function createStatsPanel() {
   let lastTime = performance.now();
   let lastUpdateTime = 0;
   // Get update interval from performance settings or use default
-  let updateInterval = window.hydraPerformanceSettings?.statsUpdateInterval || 500;
+  const updateInterval = window.hydraPerformanceSettings?.statsUpdateInterval || 500;
   let frameTimeSum = 0;
   let frameTimeSamples = 0;
 
@@ -1050,7 +1053,7 @@ export function createStatsPanel() {
       section: slotsSection,
       moveToNextSlotCheckbox: moveToNextSlotCheckbox,
     },
-    docsButton // Expose docs button for external access
+    docsButton, // Expose docs button for external access
   };
 }
 
@@ -1075,9 +1078,9 @@ function makeDraggable(element, handle, panelId) {
       const rect = element.getBoundingClientRect();
 
       // Calculate position based on right alignment
-      const rightOffset = parseInt(element.style.right || "0");
+      const rightOffset = Number.parseInt(element.style.right || "0");
       currentX = window.innerWidth - rect.width - rightOffset;
-      currentY = parseInt(element.style.top || "0");
+      currentY = Number.parseInt(element.style.top || "0");
 
       // Set explicit left position based on current right position
       element.style.left = currentX + "px";
@@ -1086,8 +1089,8 @@ function makeDraggable(element, handle, panelId) {
       element.style.right = "";
     } else {
       // Already positioned by left/top (from saved position or default)
-      currentX = parseInt(element.style.left || "0");
-      currentY = parseInt(element.style.top || "0");
+      currentX = Number.parseInt(element.style.left || "0");
+      currentY = Number.parseInt(element.style.top || "0");
     }
 
     // Save initial position if we have a panelId
@@ -1117,8 +1120,8 @@ function makeDraggable(element, handle, panelId) {
 
     // Get current element position from inline style
     // This fixes the initial jump by using the stored position
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Start dragging
     isDragging = true;
@@ -1157,8 +1160,8 @@ function makeDraggable(element, handle, panelId) {
     if (!isDragging) return;
 
     // Update current position with final offsets
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Save position to localStorage if we have a panelId
     if (panelId) {

--- a/src/XYPadPanel.js
+++ b/src/XYPadPanel.js
@@ -2,8 +2,8 @@
  * XY Pad Panel
  * A visual representation of the Korg nanoPAD's XY pad
  */
-import { setupPanelPersistence, savePanelPosition } from './utils/PanelStorage.js';
-import { XYPhysics } from './utils/XYPhysics.js';
+import { savePanelPosition, setupPanelPersistence } from "./utils/PanelStorage.js";
+import { XYPhysics } from "./utils/XYPhysics.js";
 
 export function createXYPadPanel() {
   // Create the panel container
@@ -14,14 +14,18 @@ export function createXYPadPanel() {
   panel.style.borderRadius = "4px";
   panel.style.boxShadow = "0 2px 8px rgba(0, 0, 0, 0.3)";
   panel.style.zIndex = "9";
-  panel.style.visibility = 'hidden';
-  panel.style.transition = 'opacity 0.3s ease, visibility 0.3s ease';
+  panel.style.visibility = "hidden";
+  panel.style.transition = "opacity 0.3s ease, visibility 0.3s ease";
 
   // Only show the panel if MIDI is available
-  if (window.midiManager && window.midiManager.isConnected() && window.midiManager.getActiveDevice()?.name.toLowerCase().includes('nanopad')) {
-    if (localStorage.getItem('hydractrl-xy-pad-visible') !== 'false') {
-      panel.style.visibility = 'visible';
-      panel.style.opacity = '1';
+  if (
+    window.midiManager &&
+    window.midiManager.isConnected() &&
+    window.midiManager.getActiveDevice()?.name.toLowerCase().includes("nanopad")
+  ) {
+    if (localStorage.getItem("hydractrl-xy-pad-visible") !== "false") {
+      panel.style.visibility = "visible";
+      panel.style.opacity = "1";
     }
   }
 
@@ -46,7 +50,8 @@ export function createXYPadPanel() {
   title.style.textTransform = "uppercase";
   title.style.display = "flex";
   title.style.color = "var(--color-text-secondary)";
-  title.innerHTML = "XY PAD <div style='display: flex; gap: .15rem; align-items: baseline; text-transform: none; margin-left: .7rem;'>(use <pre style='font-family: monospace'>nanoX</pre> & <pre style='font-family: monospace'>nanoY</pre>)</div>"
+  title.innerHTML =
+    "XY PAD <div style='display: flex; gap: .15rem; align-items: baseline; text-transform: none; margin-left: .7rem;'>(use <pre style='font-family: monospace'>nanoX</pre> & <pre style='font-family: monospace'>nanoY</pre>)</div>";
 
   // Create the close button
   const closeButton = document.createElement("button");
@@ -186,14 +191,19 @@ export function createXYPadPanel() {
   document.body.appendChild(panel);
 
   // Set up panel position persistence (only for position, not size)
-  const { savePosition } = setupPanelPersistence(panel, 'xy-pad', {
-    left: 20,
-    top: 20,
-  }, {
-    width: 256, // 240px pad + 16px margins
-    height: 'fit-content',
-    skipSizeRestore: true // Don't restore size from localStorage
-  });
+  const { savePosition } = setupPanelPersistence(
+    panel,
+    "xy-pad",
+    {
+      left: 20,
+      top: 20,
+    },
+    {
+      width: 256, // 240px pad + 16px margins
+      height: "fit-content",
+      skipSizeRestore: true, // Don't restore size from localStorage
+    },
+  );
 
   // Initialize physics system
   const physics = new XYPhysics(padArea.offsetWidth, padArea.offsetHeight, { historySize: 3 });
@@ -202,10 +212,11 @@ export function createXYPadPanel() {
   // Track pad interaction state and physics values
   let isPadActive = false;
   let isCoiling = false;
-  let indicatorPixelX = 0, indicatorPixelY = 0;
+  let indicatorPixelX = 0,
+    indicatorPixelY = 0;
 
   // Make the panel draggable
-  makeDraggable(panel, handle, 'xy-pad');
+  makeDraggable(panel, handle, "xy-pad");
 
   // --- Coil Interaction Logic ---
   const handleCoilMove = (e) => {
@@ -247,7 +258,7 @@ export function createXYPadPanel() {
 
     const velocityScale = 3; // Adjust this to control launch speed
     physics.vx = dxPixels * velocityScale;
-    physics.vy = - dyPixels * velocityScale;
+    physics.vy = -dyPixels * velocityScale;
 
     // Physics will resume in the animate loop if isPhysicsEnabled is true
     // isPadActive remains false, user needs to click pad or indicator again
@@ -274,12 +285,15 @@ export function createXYPadPanel() {
     // Ensure physics.x and physics.y are up-to-date if not actively moving
     const currentIndicatorRect = indicator.getBoundingClientRect();
     const padAreaRect = padArea.getBoundingClientRect();
-    indicatorPixelX = (currentIndicatorRect.left + currentIndicatorRect.width / 2) - padAreaRect.left;
-    indicatorPixelY = (currentIndicatorRect.top + currentIndicatorRect.height / 2) - padAreaRect.top;
+    indicatorPixelX = currentIndicatorRect.left + currentIndicatorRect.width / 2 - padAreaRect.left;
+    indicatorPixelY = currentIndicatorRect.top + currentIndicatorRect.height / 2 - padAreaRect.top;
 
     // Update physics object's internal position to match the visual indicator before coiling
     // This ensures the coil starts from the visually correct point if physics was idle.
-    physics.setPosition(indicatorPixelX / padArea.offsetWidth, 1 - (indicatorPixelY / padArea.offsetHeight));
+    physics.setPosition(
+      indicatorPixelX / padArea.offsetWidth,
+      1 - indicatorPixelY / padArea.offsetHeight,
+    );
 
     coilLine.setAttribute("x1", indicatorPixelX);
     coilLine.setAttribute("y1", indicatorPixelY);
@@ -331,8 +345,8 @@ export function createXYPadPanel() {
 
   function updatePhysicsParams() {
     physics.updateParams({
-      friction: parseFloat(frictionControl.slider.value),
-      bounce: parseFloat(bounceControl.slider.value)
+      friction: Number.parseFloat(frictionControl.slider.value),
+      bounce: Number.parseFloat(bounceControl.slider.value),
     });
   }
 
@@ -346,7 +360,9 @@ export function createXYPadPanel() {
     const top = (1 - y) * padArea.offsetHeight; // Invert Y axis to match MIDI orientation
     indicator.style.left = `${left}px`;
     indicator.style.top = `${top}px`;
-    indicator.style.backgroundColor = isActive ? "var(--color-text-primary)" : "var(--color-text-secondary)";
+    indicator.style.backgroundColor = isActive
+      ? "var(--color-text-primary)"
+      : "var(--color-text-secondary)";
     indicator.style.opacity = isActive ? "1" : "0.5";
 
     // Return normalized values for MIDI output
@@ -356,7 +372,7 @@ export function createXYPadPanel() {
   // Show/hide panel
   function togglePanel(show) {
     panel.style.visibility = show ? "visible" : "hidden";
-    localStorage.setItem('hydractrl-xy-pad-visible', show);
+    localStorage.setItem("hydractrl-xy-pad-visible", show);
   }
 
   // Close button functionality
@@ -373,7 +389,7 @@ export function createXYPadPanel() {
     updateFromMIDIY,
     handlePadRelease,
     togglePanel,
-    isVisible: () => panel.style.visibility === "visible"
+    isVisible: () => panel.style.visibility === "visible",
   };
 
   // Register with MIDI manager if available
@@ -405,9 +421,9 @@ function makeDraggable(element, handle, panelId) {
       const rect = element.getBoundingClientRect();
 
       // Calculate position based on right alignment
-      const rightOffset = parseInt(element.style.right || "0");
+      const rightOffset = Number.parseInt(element.style.right || "0");
       currentX = window.innerWidth - rect.width - rightOffset;
-      currentY = parseInt(element.style.top || "0");
+      currentY = Number.parseInt(element.style.top || "0");
 
       // Set explicit left position based on current right position
       element.style.left = currentX + "px";
@@ -416,8 +432,8 @@ function makeDraggable(element, handle, panelId) {
       element.style.right = "";
     } else {
       // Already positioned by left/top (from saved position or default)
-      currentX = parseInt(element.style.left || "0");
-      currentY = parseInt(element.style.top || "0");
+      currentX = Number.parseInt(element.style.left || "0");
+      currentY = Number.parseInt(element.style.top || "0");
     }
 
     // Save initial position if we have a panelId
@@ -447,8 +463,8 @@ function makeDraggable(element, handle, panelId) {
 
     // Get current element position from inline style
     // This fixes the initial jump by using the stored position
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Start dragging
     isDragging = true;
@@ -487,8 +503,8 @@ function makeDraggable(element, handle, panelId) {
     if (!isDragging) return;
 
     // Update current position with final offsets
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Save position to localStorage if we have a panelId
     if (panelId) {

--- a/src/client/core/EventBus.js
+++ b/src/client/core/EventBus.js
@@ -1,0 +1,81 @@
+/**
+ * EventBus - minimal publish/subscribe hub used to decouple panels and plugins.
+ *
+ * Listener errors are isolated: a throwing listener never prevents other
+ * listeners from running (critical during live performances).
+ */
+export function createEventBus() {
+  // Map<eventName, Set<listener>>
+  const listeners = new Map();
+
+  /**
+   * Subscribe to an event.
+   * @param {string} event - Event name (e.g. "code:run").
+   * @param {(payload: any) => void} handler
+   * @returns {() => void} Unsubscribe function.
+   */
+  function on(event, handler) {
+    if (typeof event !== "string" || typeof handler !== "function") {
+      throw new TypeError("EventBus.on requires an event name and a handler function");
+    }
+    if (!listeners.has(event)) {
+      listeners.set(event, new Set());
+    }
+    listeners.get(event).add(handler);
+    return () => off(event, handler);
+  }
+
+  /**
+   * Subscribe to an event, automatically unsubscribing after the first call.
+   */
+  function once(event, handler) {
+    const unsubscribe = on(event, (payload) => {
+      unsubscribe();
+      handler(payload);
+    });
+    return unsubscribe;
+  }
+
+  /** Unsubscribe a handler from an event. */
+  function off(event, handler) {
+    const set = listeners.get(event);
+    if (!set) return;
+    set.delete(handler);
+    if (set.size === 0) {
+      listeners.delete(event);
+    }
+  }
+
+  /**
+   * Emit an event to all subscribers. Errors thrown by individual handlers
+   * are logged and swallowed so one broken subscriber can't break the rest.
+   * @returns {number} Number of handlers invoked.
+   */
+  function emit(event, payload) {
+    const set = listeners.get(event);
+    if (!set || set.size === 0) return 0;
+    let invoked = 0;
+    // Copy so handlers that unsubscribe during emit don't skip others
+    for (const handler of [...set]) {
+      try {
+        handler(payload);
+        invoked++;
+      } catch (error) {
+        console.error(`EventBus: error in listener for "${event}":`, error);
+      }
+    }
+    return invoked;
+  }
+
+  /** Number of listeners for an event (mainly for tests/diagnostics). */
+  function listenerCount(event) {
+    return listeners.get(event)?.size || 0;
+  }
+
+  /** Remove all listeners (for teardown in tests). */
+  function clear() {
+    listeners.clear();
+  }
+
+  return { on, once, off, emit, listenerCount, clear };
+}

--- a/src/client/core/EventBus.test.js
+++ b/src/client/core/EventBus.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { createEventBus } from "./EventBus.js";
+
+describe("EventBus", () => {
+  test("delivers payloads to subscribers", () => {
+    const bus = createEventBus();
+    const received = [];
+    bus.on("tick", (payload) => received.push(payload));
+
+    bus.emit("tick", 1);
+    bus.emit("tick", 2);
+
+    expect(received).toEqual([1, 2]);
+  });
+
+  test("emit returns the number of handlers invoked", () => {
+    const bus = createEventBus();
+    bus.on("tick", () => {});
+    bus.on("tick", () => {});
+
+    expect(bus.emit("tick")).toBe(2);
+    expect(bus.emit("unknown")).toBe(0);
+  });
+
+  test("on returns an unsubscribe function", () => {
+    const bus = createEventBus();
+    let calls = 0;
+    const unsubscribe = bus.on("tick", () => calls++);
+
+    bus.emit("tick");
+    unsubscribe();
+    bus.emit("tick");
+
+    expect(calls).toBe(1);
+    expect(bus.listenerCount("tick")).toBe(0);
+  });
+
+  test("once only fires a single time", () => {
+    const bus = createEventBus();
+    let calls = 0;
+    bus.once("tick", () => calls++);
+
+    bus.emit("tick");
+    bus.emit("tick");
+
+    expect(calls).toBe(1);
+  });
+
+  test("a throwing listener does not break other listeners", () => {
+    const bus = createEventBus();
+    const received = [];
+    bus.on("tick", () => {
+      throw new Error("boom");
+    });
+    bus.on("tick", (payload) => received.push(payload));
+
+    expect(() => bus.emit("tick", "ok")).not.toThrow();
+    expect(received).toEqual(["ok"]);
+  });
+
+  test("unsubscribing during emit does not skip other handlers", () => {
+    const bus = createEventBus();
+    const received = [];
+    const unsubscribeA = bus.on("tick", () => {
+      received.push("a");
+      unsubscribeA();
+    });
+    bus.on("tick", () => received.push("b"));
+
+    bus.emit("tick");
+
+    expect(received).toEqual(["a", "b"]);
+  });
+
+  test("off and clear remove listeners", () => {
+    const bus = createEventBus();
+    const handler = () => {};
+    bus.on("tick", handler);
+    bus.off("tick", handler);
+    expect(bus.listenerCount("tick")).toBe(0);
+
+    bus.on("a", () => {});
+    bus.on("b", () => {});
+    bus.clear();
+    expect(bus.listenerCount("a")).toBe(0);
+    expect(bus.listenerCount("b")).toBe(0);
+  });
+
+  test("rejects invalid subscriptions", () => {
+    const bus = createEventBus();
+    expect(() => bus.on(null, () => {})).toThrow(TypeError);
+    expect(() => bus.on("tick", null)).toThrow(TypeError);
+  });
+});

--- a/src/client/core/PluginHost.js
+++ b/src/client/core/PluginHost.js
@@ -1,0 +1,137 @@
+/**
+ * PluginHost - lightweight plugin system for HYDRACTRL.
+ *
+ * A plugin is a plain object:
+ *
+ *   {
+ *     id: "my-plugin",            // required, unique
+ *     name: "My Plugin",          // optional, for display
+ *     description: "...",         // optional
+ *     setup(ctx) { ... },         // called once when the host initializes
+ *                                 // (or immediately when registered after init).
+ *                                 // May return a cleanup function or an API object:
+ *                                 //   return { api: {...}, dispose() {...} }
+ *   }
+ *
+ * `ctx` is the shared application context assembled in index.js:
+ *   { hydra, editor, runCode, events, storage, notify, getPanels() }
+ *
+ * Design goals:
+ *  - Error isolation: a plugin that throws during setup or teardown is
+ *    disabled and logged, but never breaks the app or other plugins.
+ *  - No load-order coupling: plugins talk to each other through ctx.events.
+ */
+export function createPluginHost(ctx) {
+  if (!ctx || typeof ctx !== "object") {
+    throw new TypeError("createPluginHost requires a context object");
+  }
+
+  // Map<id, { plugin, status, api, dispose, error }>
+  const registry = new Map();
+  let initialized = false;
+
+  function validate(plugin) {
+    if (!plugin || typeof plugin !== "object") {
+      return "plugin must be an object";
+    }
+    if (typeof plugin.id !== "string" || plugin.id.length === 0) {
+      return "plugin.id must be a non-empty string";
+    }
+    if (registry.has(plugin.id)) {
+      return `duplicate plugin id "${plugin.id}"`;
+    }
+    if (typeof plugin.setup !== "function") {
+      return "plugin.setup must be a function";
+    }
+    return null;
+  }
+
+  function runSetup(entry) {
+    const { plugin } = entry;
+    try {
+      const result = plugin.setup(ctx);
+      if (typeof result === "function") {
+        entry.dispose = result;
+      } else if (result && typeof result === "object") {
+        entry.api = result.api || null;
+        entry.dispose = typeof result.dispose === "function" ? result.dispose : null;
+      }
+      entry.status = "active";
+      ctx.events?.emit("plugin:activated", { id: plugin.id });
+    } catch (error) {
+      entry.status = "error";
+      entry.error = error;
+      console.error(`PluginHost: plugin "${plugin.id}" failed during setup:`, error);
+      ctx.events?.emit("plugin:error", { id: plugin.id, error });
+    }
+  }
+
+  /**
+   * Register a plugin. If the host is already initialized the plugin is
+   * set up immediately; otherwise setup is deferred until init().
+   * @returns {boolean} true if the plugin was accepted.
+   */
+  function register(plugin) {
+    const problem = validate(plugin);
+    if (problem) {
+      console.error(`PluginHost: rejected plugin: ${problem}`);
+      return false;
+    }
+    const entry = { plugin, status: "registered", api: null, dispose: null, error: null };
+    registry.set(plugin.id, entry);
+    if (initialized) {
+      runSetup(entry);
+    }
+    return true;
+  }
+
+  /** Set up all registered plugins. Safe to call once. */
+  function init() {
+    if (initialized) return;
+    initialized = true;
+    for (const entry of registry.values()) {
+      if (entry.status === "registered") {
+        runSetup(entry);
+      }
+    }
+    ctx.events?.emit("plugins:ready", { ids: [...registry.keys()] });
+  }
+
+  /** Tear down and remove a plugin. @returns {boolean} */
+  function unregister(id) {
+    const entry = registry.get(id);
+    if (!entry) return false;
+    if (entry.dispose) {
+      try {
+        entry.dispose();
+      } catch (error) {
+        console.error(`PluginHost: plugin "${id}" failed during teardown:`, error);
+      }
+    }
+    registry.delete(id);
+    ctx.events?.emit("plugin:removed", { id });
+    return true;
+  }
+
+  /** Public API object returned by a plugin's setup, if any. */
+  function getApi(id) {
+    return registry.get(id)?.api || null;
+  }
+
+  /** Status of one plugin: "registered" | "active" | "error" | null. */
+  function getStatus(id) {
+    return registry.get(id)?.status || null;
+  }
+
+  /** Snapshot of all plugins for diagnostics. */
+  function list() {
+    return [...registry.values()].map((entry) => ({
+      id: entry.plugin.id,
+      name: entry.plugin.name || entry.plugin.id,
+      description: entry.plugin.description || "",
+      status: entry.status,
+    }));
+  }
+
+  return { register, unregister, init, getApi, getStatus, list };
+}

--- a/src/client/core/PluginHost.test.js
+++ b/src/client/core/PluginHost.test.js
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import { createEventBus } from "./EventBus.js";
+import { createPluginHost } from "./PluginHost.js";
+
+function createHost() {
+  const events = createEventBus();
+  const ctx = { events, notify: () => {} };
+  return { host: createPluginHost(ctx), events, ctx };
+}
+
+describe("PluginHost", () => {
+  test("requires a context object", () => {
+    expect(() => createPluginHost()).toThrow(TypeError);
+  });
+
+  test("registers and initializes plugins with the shared context", () => {
+    const { host, ctx } = createHost();
+    let receivedCtx = null;
+
+    host.register({
+      id: "p1",
+      setup(context) {
+        receivedCtx = context;
+      },
+    });
+
+    expect(host.getStatus("p1")).toBe("registered");
+    host.init();
+    expect(host.getStatus("p1")).toBe("active");
+    expect(receivedCtx).toBe(ctx);
+  });
+
+  test("rejects malformed plugins", () => {
+    const { host } = createHost();
+
+    expect(host.register(null)).toBe(false);
+    expect(host.register({})).toBe(false);
+    expect(host.register({ id: "x" })).toBe(false);
+    expect(host.register({ id: "", setup() {} })).toBe(false);
+  });
+
+  test("rejects duplicate plugin ids", () => {
+    const { host } = createHost();
+    expect(host.register({ id: "dup", setup() {} })).toBe(true);
+    expect(host.register({ id: "dup", setup() {} })).toBe(false);
+  });
+
+  test("a plugin that throws during setup is isolated", () => {
+    const { host } = createHost();
+    let goodPluginRan = false;
+
+    host.register({
+      id: "bad",
+      setup() {
+        throw new Error("setup exploded");
+      },
+    });
+    host.register({
+      id: "good",
+      setup() {
+        goodPluginRan = true;
+      },
+    });
+
+    expect(() => host.init()).not.toThrow();
+    expect(host.getStatus("bad")).toBe("error");
+    expect(host.getStatus("good")).toBe("active");
+    expect(goodPluginRan).toBe(true);
+  });
+
+  test("plugins registered after init are set up immediately", () => {
+    const { host } = createHost();
+    host.init();
+
+    let ran = false;
+    host.register({
+      id: "late",
+      setup() {
+        ran = true;
+      },
+    });
+
+    expect(ran).toBe(true);
+    expect(host.getStatus("late")).toBe("active");
+  });
+
+  test("exposes the api returned from setup", () => {
+    const { host } = createHost();
+    host.register({
+      id: "with-api",
+      setup() {
+        return { api: { hello: () => "world" } };
+      },
+    });
+    host.init();
+
+    expect(host.getApi("with-api").hello()).toBe("world");
+    expect(host.getApi("missing")).toBe(null);
+  });
+
+  test("unregister calls dispose and removes the plugin", () => {
+    const { host } = createHost();
+    let disposed = false;
+    host.register({
+      id: "disposable",
+      setup() {
+        return {
+          dispose() {
+            disposed = true;
+          },
+        };
+      },
+    });
+    host.init();
+
+    expect(host.unregister("disposable")).toBe(true);
+    expect(disposed).toBe(true);
+    expect(host.getStatus("disposable")).toBe(null);
+    expect(host.unregister("disposable")).toBe(false);
+  });
+
+  test("setup may return a plain cleanup function", () => {
+    const { host } = createHost();
+    let disposed = false;
+    host.register({
+      id: "fn-cleanup",
+      setup() {
+        return () => {
+          disposed = true;
+        };
+      },
+    });
+    host.init();
+    host.unregister("fn-cleanup");
+
+    expect(disposed).toBe(true);
+  });
+
+  test("a throwing dispose does not prevent removal", () => {
+    const { host } = createHost();
+    host.register({
+      id: "bad-dispose",
+      setup() {
+        return () => {
+          throw new Error("dispose exploded");
+        };
+      },
+    });
+    host.init();
+
+    expect(() => host.unregister("bad-dispose")).not.toThrow();
+    expect(host.getStatus("bad-dispose")).toBe(null);
+  });
+
+  test("emits lifecycle events on the bus", () => {
+    const { host, events } = createHost();
+    const seen = [];
+    events.on("plugin:activated", (e) => seen.push(`activated:${e.id}`));
+    events.on("plugins:ready", (e) => seen.push(`ready:${e.ids.join(",")}`));
+    events.on("plugin:removed", (e) => seen.push(`removed:${e.id}`));
+
+    host.register({ id: "a", setup() {} });
+    host.init();
+    host.unregister("a");
+
+    expect(seen).toEqual(["activated:a", "ready:a", "removed:a"]);
+  });
+
+  test("list reports plugin metadata and status", () => {
+    const { host } = createHost();
+    host.register({ id: "a", name: "Plugin A", description: "does a", setup() {} });
+    host.register({
+      id: "b",
+      setup() {
+        throw new Error("no");
+      },
+    });
+    host.init();
+
+    expect(host.list()).toEqual([
+      { id: "a", name: "Plugin A", description: "does a", status: "active" },
+      { id: "b", name: "b", description: "", status: "error" },
+    ]);
+  });
+});

--- a/src/client/core/Storage.js
+++ b/src/client/core/Storage.js
@@ -1,0 +1,110 @@
+/**
+ * Storage - a safe wrapper around localStorage.
+ *
+ * Every direct localStorage call can throw: quota exceeded (thumbnails add up
+ * fast), privacy mode, or disabled storage. During a live set an unhandled
+ * QuotaExceededError must never take the app down, so all operations here are
+ * guarded and report failures through their return values instead of throwing.
+ */
+
+/**
+ * @param {object} [options]
+ * @param {Storage} [options.backend] - Storage backend, defaults to window.localStorage.
+ *   Injectable for tests and non-browser environments.
+ * @param {(error: Error, key: string) => void} [options.onWriteError] - Called when a
+ *   write fails even after quota recovery was attempted.
+ */
+export function createSafeStorage(options = {}) {
+  const backend = options.backend || (typeof localStorage !== "undefined" ? localStorage : null);
+  const onWriteError = options.onWriteError || (() => {});
+
+  function isAvailable() {
+    if (!backend) return false;
+    try {
+      const probe = "__hydractrl_probe__";
+      backend.setItem(probe, "1");
+      backend.removeItem(probe);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  /** @returns {string|null} */
+  function get(key, fallback = null) {
+    if (!backend) return fallback;
+    try {
+      const value = backend.getItem(key);
+      return value === null ? fallback : value;
+    } catch (error) {
+      console.warn(`Storage: failed to read "${key}":`, error);
+      return fallback;
+    }
+  }
+
+  /** @returns {boolean} true if the write succeeded */
+  function set(key, value) {
+    if (!backend) return false;
+    try {
+      backend.setItem(key, String(value));
+      return true;
+    } catch (error) {
+      console.warn(`Storage: failed to write "${key}":`, error);
+      onWriteError(error, key);
+      return false;
+    }
+  }
+
+  function remove(key) {
+    if (!backend) return false;
+    try {
+      backend.removeItem(key);
+      return true;
+    } catch (error) {
+      console.warn(`Storage: failed to remove "${key}":`, error);
+      return false;
+    }
+  }
+
+  /** Read and JSON-parse a value. Returns fallback on missing or corrupt data. */
+  function getJSON(key, fallback = null) {
+    const raw = get(key);
+    if (raw === null) return fallback;
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn(`Storage: corrupt JSON in "${key}", using fallback:`, error);
+      return fallback;
+    }
+  }
+
+  /** JSON-stringify and store a value. @returns {boolean} */
+  function setJSON(key, value) {
+    try {
+      return set(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn(`Storage: failed to serialize "${key}":`, error);
+      return false;
+    }
+  }
+
+  /** All keys, optionally filtered by prefix. Never throws. */
+  function keys(prefix = "") {
+    if (!backend) return [];
+    try {
+      const result = [];
+      for (let i = 0; i < backend.length; i++) {
+        const key = backend.key(i);
+        if (key !== null && key.startsWith(prefix)) {
+          result.push(key);
+        }
+      }
+      return result;
+    } catch (error) {
+      console.warn("Storage: failed to enumerate keys:", error);
+      return [];
+    }
+  }
+
+  return { get, set, remove, getJSON, setJSON, keys, isAvailable };
+}

--- a/src/client/core/Storage.test.js
+++ b/src/client/core/Storage.test.js
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { createSafeStorage } from "./Storage.js";
+
+/** Minimal in-memory implementation of the Web Storage interface. */
+function createMemoryBackend() {
+  const map = new Map();
+  return {
+    getItem: (key) => (map.has(key) ? map.get(key) : null),
+    setItem: (key, value) => map.set(key, String(value)),
+    removeItem: (key) => map.delete(key),
+    key: (index) => [...map.keys()][index] ?? null,
+    get length() {
+      return map.size;
+    },
+    _map: map,
+  };
+}
+
+/** Backend whose writes always fail, like a full or disabled localStorage. */
+function createThrowingBackend() {
+  const backend = createMemoryBackend();
+  backend.setItem = () => {
+    throw new DOMException("quota exceeded", "QuotaExceededError");
+  };
+  return backend;
+}
+
+describe("createSafeStorage", () => {
+  test("get/set/remove round-trip", () => {
+    const storage = createSafeStorage({ backend: createMemoryBackend() });
+
+    expect(storage.set("k", "v")).toBe(true);
+    expect(storage.get("k")).toBe("v");
+    expect(storage.remove("k")).toBe(true);
+    expect(storage.get("k")).toBe(null);
+  });
+
+  test("get returns fallback for missing keys", () => {
+    const storage = createSafeStorage({ backend: createMemoryBackend() });
+    expect(storage.get("missing", "default")).toBe("default");
+  });
+
+  test("set coerces values to strings like localStorage does", () => {
+    const storage = createSafeStorage({ backend: createMemoryBackend() });
+    storage.set("n", 42);
+    storage.set("b", true);
+    expect(storage.get("n")).toBe("42");
+    expect(storage.get("b")).toBe("true");
+  });
+
+  test("write failure returns false and reports instead of throwing", () => {
+    let reportedKey = null;
+    const storage = createSafeStorage({
+      backend: createThrowingBackend(),
+      onWriteError: (_error, key) => {
+        reportedKey = key;
+      },
+    });
+
+    expect(() => storage.set("k", "v")).not.toThrow();
+    expect(storage.set("k", "v")).toBe(false);
+    expect(reportedKey).toBe("k");
+  });
+
+  test("getJSON/setJSON round-trip objects", () => {
+    const storage = createSafeStorage({ backend: createMemoryBackend() });
+    const value = { banks: [1, 2, 3], name: "live-set" };
+
+    expect(storage.setJSON("cfg", value)).toBe(true);
+    expect(storage.getJSON("cfg")).toEqual(value);
+  });
+
+  test("getJSON returns fallback for corrupt data", () => {
+    const backend = createMemoryBackend();
+    backend.setItem("cfg", "{not json");
+    const storage = createSafeStorage({ backend });
+
+    expect(storage.getJSON("cfg", { ok: true })).toEqual({ ok: true });
+  });
+
+  test("setJSON returns false for unserializable values", () => {
+    const storage = createSafeStorage({ backend: createMemoryBackend() });
+    const circular = {};
+    circular.self = circular;
+    expect(storage.setJSON("cfg", circular)).toBe(false);
+  });
+
+  test("keys filters by prefix", () => {
+    const storage = createSafeStorage({ backend: createMemoryBackend() });
+    storage.set("hydractrl-slot-1", "a");
+    storage.set("hydractrl-slot-2", "b");
+    storage.set("other", "c");
+
+    expect(storage.keys("hydractrl-slot-").sort()).toEqual([
+      "hydractrl-slot-1",
+      "hydractrl-slot-2",
+    ]);
+    expect(storage.keys().length).toBe(3);
+  });
+
+  test("works degraded without any backend", () => {
+    const storage = createSafeStorage({ backend: null });
+    // In non-browser environments there is no localStorage at all;
+    // every operation must still be safe to call.
+    expect(storage.isAvailable()).toBe(false);
+    expect(storage.get("k", "fallback")).toBe("fallback");
+    expect(storage.set("k", "v")).toBe(false);
+    expect(storage.remove("k")).toBe(false);
+    expect(storage.keys()).toEqual([]);
+  });
+
+  test("isAvailable reflects backend health", () => {
+    expect(createSafeStorage({ backend: createMemoryBackend() }).isAvailable()).toBe(true);
+    expect(createSafeStorage({ backend: createThrowingBackend() }).isAvailable()).toBe(false);
+  });
+});

--- a/src/client/core/notify.js
+++ b/src/client/core/notify.js
@@ -1,0 +1,51 @@
+/**
+ * notify - unified toast notifications.
+ *
+ * Replaces the half-dozen hand-rolled ".saved-notification" blocks that were
+ * duplicated across the codebase, each with its own timers and cleanup bugs.
+ */
+
+const DEFAULT_DURATION_MS = 2000;
+const FADE_MS = 500;
+
+/**
+ * Show a transient toast notification.
+ * @param {string} message
+ * @param {object} [options]
+ * @param {"info"|"success"|"error"} [options.type]
+ * @param {number} [options.duration] - Visible time in ms before fade-out.
+ * @returns {HTMLElement|null} The toast element (null outside a DOM environment).
+ */
+export function notify(message, options = {}) {
+  if (typeof document === "undefined") return null;
+  const { type = "info", duration = DEFAULT_DURATION_MS } = options;
+
+  const toast = document.createElement("div");
+  toast.className = "saved-notification";
+  if (type === "error") {
+    toast.style.backgroundColor = "var(--color-error, rgba(255, 85, 85, 0.9))";
+  } else if (type === "success") {
+    toast.style.backgroundColor = "rgba(80, 250, 123, 0.85)";
+  }
+  toast.textContent = message;
+  document.body.appendChild(toast);
+
+  const dismiss = () => {
+    toast.classList.add("fade-out");
+    setTimeout(() => {
+      toast.remove();
+    }, FADE_MS);
+  };
+
+  toast.addEventListener("click", dismiss);
+  setTimeout(dismiss, duration);
+  return toast;
+}
+
+export function notifySuccess(message, options = {}) {
+  return notify(message, { ...options, type: "success" });
+}
+
+export function notifyError(message, options = {}) {
+  return notify(message, { ...options, type: "error", duration: options.duration ?? 4000 });
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,10 +1,10 @@
+import { createDocPanel } from "../DocPanel.js";
+import { createMidiManager } from "../MidiManager.js";
+import { createSlotsPanel } from "../SlotsPanel.js";
 // Import utilities
-import {createStatsPanel} from "../StatsPanel.js";
-import {createSlotsPanel} from "../SlotsPanel.js";
-import {createDocPanel} from "../DocPanel.js";
-import {createCodeMirrorEditor} from "../utils/CodeMirrorEditor.js";
-import {createMidiManager} from "../MidiManager.js";
-import {loadPanelPosition, savePanelPosition} from "../utils/PanelStorage.js";
+import { createStatsPanel } from "../StatsPanel.js";
+import { createCodeMirrorEditor } from "../utils/CodeMirrorEditor.js";
+import { loadPanelPosition, savePanelPosition } from "../utils/PanelStorage.js";
 
 // Helper function to debounce events
 function debounce(func, wait) {
@@ -39,11 +39,13 @@ function initEditor() {
   editorContainer.style.overflow = "auto";
 
   // Initialize tab state with persistent setup code
-  const savedSetupCode = localStorage.getItem("hydractrl-setup-code") || "// Setup code runs once before main code\n// Use this for audio settings, global variables, etc.\n// This only persists in your browser and will not be exported to JSON.\n\n";
-  
+  const savedSetupCode =
+    localStorage.getItem("hydractrl-setup-code") ||
+    "// Setup code runs once before main code\n// Use this for audio settings, global variables, etc.\n// This only persists in your browser and will not be exported to JSON.\n\n";
+
   const editorTabs = {
     main: { code: DEFAULT_CODE },
-    setup: { code: savedSetupCode }
+    setup: { code: savedSetupCode },
   };
   let currentTab = "main";
 
@@ -52,23 +54,23 @@ function initEditor() {
 
   // Add tab switching functionality
   const tabButtons = document.querySelectorAll(".editor-tab");
-  tabButtons.forEach(button => {
+  tabButtons.forEach((button) => {
     button.addEventListener("click", () => {
       // Save current editor content
       editorTabs[currentTab].code = editor.getCode();
-      
+
       // If leaving setup tab, save to localStorage
       if (currentTab === "setup") {
         localStorage.setItem("hydractrl-setup-code", editor.getCode());
       }
-      
+
       // Switch to new tab
       currentTab = button.dataset.tab;
-      
+
       // Update active tab UI
-      tabButtons.forEach(btn => btn.classList.remove("active"));
+      tabButtons.forEach((btn) => btn.classList.remove("active"));
       button.classList.add("active");
-      
+
       // Load new tab content
       editor.setCode(editorTabs[currentTab].code);
       editor.focus();
@@ -90,12 +92,12 @@ function initEditor() {
   editor.getAllCode = () => {
     // Save current editor content first
     editorTabs[currentTab].code = editor.getCode();
-    
+
     // Always return setup + main code, regardless of current tab
     // This ensures setup always runs with the main sketch
     return {
       setup: editorTabs.setup.code,
-      main: editorTabs.main.code
+      main: editorTabs.main.code,
     };
   };
 
@@ -103,34 +105,32 @@ function initEditor() {
   editor.setAllCode = (setupCode, mainCode) => {
     editorTabs.setup.code = setupCode || "";
     editorTabs.main.code = mainCode || "";
-    
+
     // Update current editor content with the appropriate tab
     editor.setCode(editorTabs[currentTab].code);
   };
 
   // Make the editor draggable by the handle with position persistence
-  makeDraggable(
-    editorContainer,
-    document.getElementById("editor-handle"),
-    "editor-panel",
-  );
+  makeDraggable(editorContainer, document.getElementById("editor-handle"), "editor-panel");
 
   // Add a resize observer to save dimensions when resized
-  const resizeObserver = new ResizeObserver(debounce(() => {
-    // Skip saving if editor is being dragged to avoid conflicts
-    if (editorContainer.classList.contains("dragging")) return;
+  const resizeObserver = new ResizeObserver(
+    debounce(() => {
+      // Skip saving if editor is being dragged to avoid conflicts
+      if (editorContainer.classList.contains("dragging")) return;
 
-    // Get the position and dimensions
-    const position = {
-      left: parseInt(editorContainer.style.left || "0"),
-      top: parseInt(editorContainer.style.top || "0"),
-      width: editorContainer.offsetWidth,
-      height: editorContainer.offsetHeight,
-    };
+      // Get the position and dimensions
+      const position = {
+        left: Number.parseInt(editorContainer.style.left || "0"),
+        top: Number.parseInt(editorContainer.style.top || "0"),
+        width: editorContainer.offsetWidth,
+        height: editorContainer.offsetHeight,
+      };
 
-    // Save to localStorage
-    savePanelPosition("editor-panel", position);
-  }, 100));
+      // Save to localStorage
+      savePanelPosition("editor-panel", position);
+    }, 100),
+  );
 
   // Start observing the editor container
   resizeObserver.observe(editorContainer);
@@ -178,18 +178,26 @@ function isWebGLSupported() {
 function isMobileOrTablet() {
   // Check user agent for mobile indicators
   const userAgent = navigator.userAgent.toLowerCase();
-  const mobileKeywords = ['mobile', 'android', 'iphone', 'ipad', 'ipod', 'blackberry', 'windows phone'];
-  const hasMobileKeyword = mobileKeywords.some(keyword => userAgent.includes(keyword));
-  
+  const mobileKeywords = [
+    "mobile",
+    "android",
+    "iphone",
+    "ipad",
+    "ipod",
+    "blackberry",
+    "windows phone",
+  ];
+  const hasMobileKeyword = mobileKeywords.some((keyword) => userAgent.includes(keyword));
+
   // Check screen size (typical mobile/tablet sizes)
   const isMobileScreen = window.innerWidth <= 1024 || window.innerHeight <= 768;
-  
+
   // Check for touch capability
-  const hasTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-  
+  const hasTouch = "ontouchstart" in window || navigator.maxTouchPoints > 0;
+
   // Check device orientation API (common on mobile devices)
-  const hasOrientation = 'orientation' in window;
-  
+  const hasOrientation = "orientation" in window;
+
   // Return true if any mobile indicator is present
   return hasMobileKeyword || (isMobileScreen && hasTouch) || hasOrientation;
 }
@@ -205,7 +213,7 @@ function createCodeOverlay() {
   const textarea = document.createElement("textarea");
   textarea.readOnly = true;
   textarea.value = DEFAULT_CODE;
-  
+
   overlay.appendChild(textarea);
   document.body.appendChild(overlay);
 
@@ -229,7 +237,7 @@ function createCodeOverlay() {
   window.codeOverlay = {
     update: updateOverlay,
     toggle: toggleOverlay,
-    element: overlay
+    element: overlay,
   };
 
   return overlay;
@@ -290,8 +298,8 @@ async function initHydra() {
     }
 
     // Get or create the canvas element
-    let canvasContainer = document.getElementById("hydra-canvas");
-    let canvas = document.createElement("canvas");
+    const canvasContainer = document.getElementById("hydra-canvas");
+    const canvas = document.createElement("canvas");
     canvas.width = canvasContainer.clientWidth || 500;
     canvas.height = canvasContainer.clientHeight || 400;
     canvas.style.width = "100%";
@@ -388,7 +396,8 @@ function createInfoPanel() {
   panel.id = "info-panel";
   panel.className = "info-panel";
   panel.style.position = "fixed";
-  panel.style.backgroundColor = "rgba(var(--color-bg-secondary-rgb), var(--panel-opacity)) !important";
+  panel.style.backgroundColor =
+    "rgba(var(--color-bg-secondary-rgb), var(--panel-opacity)) !important";
   panel.style.borderRadius = "8px";
   panel.style.boxShadow = "0 4px 15px var(--color-panel-shadow)";
   panel.style.backdropFilter = "blur(var(--color-panel-blur))";
@@ -523,11 +532,11 @@ function createInfoPanel() {
     { keys: "Alt/⌥ + 0-9 / A-F", action: "Select slot 1 to 16 (HEX)" },
     { keys: "Alt/⌥ + ←/→", action: "Cycle between banks (only when no MIDI connected)" },
     { keys: "Alt/⌥ + X", action: "Export all slots" },
-    { keys: "Alt/⌥ + I", action: "Import slots file" }
+    { keys: "Alt/⌥ + I", action: "Import slots file" },
   ];
 
   // Add shortcuts to table
-  shortcuts.forEach(shortcut => {
+  shortcuts.forEach((shortcut) => {
     const row = document.createElement("tr");
     row.style.borderBottom = "1px solid var(--color-bg-tertiary)";
 
@@ -561,7 +570,8 @@ function createInfoPanel() {
   const showOnStartupCheckbox = document.createElement("input");
   showOnStartupCheckbox.type = "checkbox";
   showOnStartupCheckbox.id = "show-on-startup";
-  showOnStartupCheckbox.checked = localStorage.getItem("hydractrl-show-info-on-startup") !== "false"; // Default to true
+  showOnStartupCheckbox.checked =
+    localStorage.getItem("hydractrl-show-info-on-startup") !== "false"; // Default to true
 
   const showOnStartupLabel = document.createElement("label");
   showOnStartupLabel.htmlFor = "show-on-startup";
@@ -687,7 +697,7 @@ function makeDraggable(element, handle, panelId) {
   setTimeout(() => {
     // Load saved position or get current position
     const savedPosition = panelId ? loadPanelPosition(panelId) : null;
-    
+
     if (savedPosition) {
       currentX = savedPosition.left;
       currentY = savedPosition.top;
@@ -725,8 +735,8 @@ function makeDraggable(element, handle, panelId) {
     initialY = e.clientY;
 
     // Get current element position from inline style
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Start dragging
     isDragging = true;
@@ -765,8 +775,8 @@ function makeDraggable(element, handle, panelId) {
     if (!isDragging) return;
 
     // Update current position with final offsets
-    currentX = parseInt(element.style.left || "0");
-    currentY = parseInt(element.style.top || "0");
+    currentX = Number.parseInt(element.style.left || "0");
+    currentY = Number.parseInt(element.style.top || "0");
 
     // Save position to localStorage if we have a panelId
     if (panelId) {
@@ -816,7 +826,7 @@ async function runCode(editor, hydra) {
 
     // Create an async function to execute the code with hydra in scope
     // This allows top-level await support
-    const AsyncFunction = Object.getPrototypeOf(async function () { }).constructor;
+    const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 
     // Combine setup and main code
     const codeToExecute = setupCode ? `${setupCode}\n\n${mainCode}` : mainCode;
@@ -935,7 +945,7 @@ function loadCode(editor) {
     editor.dispatch({
       changes: { from: 0, to: editor.state.doc.length, insert: savedCode },
     });
-    
+
     // Update mobile code overlay if available
     if (window.codeOverlay) {
       window.codeOverlay.update(savedCode);
@@ -966,7 +976,7 @@ async function importDefaultScenesIfEmpty() {
       console.log("No saved scenes found. Importing default extension pack...");
 
       // Fetch the default extension pack
-      const response = await fetch('/assets/banks/hydractrl-init-basic.json');
+      const response = await fetch("/assets/banks/hydractrl-init-basic.json");
       if (!response.ok) {
         throw new Error(`Failed to fetch default extension pack: ${response.status}`);
       }
@@ -1093,8 +1103,8 @@ async function initBreakoutHydra(breakoutWindow) {
     }
 
     // Get or create the canvas element in the breakout window
-    let canvasContainer = breakoutWindow.document.getElementById("hydra-canvas-breakout");
-    let canvas = breakoutWindow.document.createElement("canvas");
+    const canvasContainer = breakoutWindow.document.getElementById("hydra-canvas-breakout");
+    const canvas = breakoutWindow.document.createElement("canvas");
     canvas.width = breakoutWindow.innerWidth || 500;
     canvas.height = breakoutWindow.innerHeight || 400;
     canvas.style.width = "100%";
@@ -1120,15 +1130,14 @@ async function initBreakoutHydra(breakoutWindow) {
     });
 
     // Define loadScript function in breakout window
-    breakoutWindow.loadScript = function (url) {
-      return new Promise((resolve, reject) => {
+    breakoutWindow.loadScript = (url) =>
+      new Promise((resolve, reject) => {
         const script = breakoutWindow.document.createElement("script");
         script.src = url;
         script.onload = resolve;
         script.onerror = reject;
         breakoutWindow.document.head.appendChild(script);
       });
-    };
 
     // Copy existing global variables and functions to breakout window
     if (window.hydraText) {
@@ -1180,7 +1189,7 @@ async function runCodeOnAllInstances(editor, mainHydra) {
 async function init() {
   try {
     const isMobile = isMobileOrTablet();
-    
+
     const editor = initEditor(); // No longer async
     const hydra = await initHydra();
 
@@ -1346,19 +1355,20 @@ async function init() {
         const keyCode = e.code; // Use e.code for physical key identification
 
         // Handle Digit0 to Digit9 for slots 0-9
-        if (keyCode.startsWith('Digit')) {
-          const digit = parseInt(keyCode.substring(5)); // e.g., "Digit0" -> 0
-          if (!isNaN(digit) && digit >= 0 && digit <= 9) {
+        if (keyCode.startsWith("Digit")) {
+          const digit = Number.parseInt(keyCode.substring(5)); // e.g., "Digit0" -> 0
+          if (!Number.isNaN(digit) && digit >= 0 && digit <= 9) {
             slotIndex = digit; // Digit0 maps to slot 0, Digit1 to 1, ..., Digit9 to 9
           }
         }
         // Handle KeyA to KeyF for slots 10-15
-        else if (keyCode.startsWith('Key')) {
+        else if (keyCode.startsWith("Key")) {
           const keyChar = keyCode.substring(3); // e.g., "KeyA" -> "A"
-          if (keyChar.length === 1) { // Ensure it's a single character like 'A', not 'F1' etc.
+          if (keyChar.length === 1) {
+            // Ensure it's a single character like 'A', not 'F1' etc.
             const charCode = keyChar.charCodeAt(0);
-            if (charCode >= 'A'.charCodeAt(0) && charCode <= 'F'.charCodeAt(0)) {
-              slotIndex = charCode - 'A'.charCodeAt(0) + 10; // KeyA maps to slot 10
+            if (charCode >= "A".charCodeAt(0) && charCode <= "F".charCodeAt(0)) {
+              slotIndex = charCode - "A".charCodeAt(0) + 10; // KeyA maps to slot 10
             }
           }
         }
@@ -1382,7 +1392,8 @@ async function init() {
 
       // Alt+Left/Right arrow keys to cycle between banks (only when no MIDI device is connected)
       if ((e.altKey || e.optKey) && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
-        if (e.code === "ArrowLeft" && window.slotsPanel && window.slotsPanel.cycleBank) { /* Use e.code */
+        if (e.code === "ArrowLeft" && window.slotsPanel && window.slotsPanel.cycleBank) {
+          /* Use e.code */
           // Check if MIDI device is connected
           const midiConnected =
             window.midiManager &&
@@ -1401,7 +1412,8 @@ async function init() {
           }
         }
 
-        if (e.code === "ArrowRight" && window.slotsPanel && window.slotsPanel.cycleBank) { /* Use e.code */
+        if (e.code === "ArrowRight" && window.slotsPanel && window.slotsPanel.cycleBank) {
+          /* Use e.code */
           // Check if MIDI device is connected
           const midiConnected =
             window.midiManager &&
@@ -1437,7 +1449,7 @@ async function init() {
 
     // Only create certain panels based on device type
     let statsPanel, docPanel, midiManager;
-    
+
     if (!isMobile) {
       // Create the stats panel using our simple implementation
       statsPanel = createStatsPanel();
@@ -1462,7 +1474,7 @@ async function init() {
       midiManager = createMidiManager(slotsPanel);
 
       // Create XY pad panel (desktop only)
-      import('./../XYPadPanel.js').then(module => {
+      import("./../XYPadPanel.js").then((module) => {
         const xyPadPanel = module.createXYPadPanel();
         window.xyPadPanel = xyPadPanel;
 
@@ -1470,7 +1482,7 @@ async function init() {
         midiManager.setXYPadPanel(xyPadPanel);
 
         // Set initial visibility based on localStorage
-        const xyPadVisible = localStorage.getItem('hydractrl-xy-pad-visible') === 'true';
+        const xyPadVisible = localStorage.getItem("hydractrl-xy-pad-visible") === "true";
         xyPadPanel.togglePanel(xyPadVisible);
       });
     }
@@ -1479,13 +1491,13 @@ async function init() {
     if (isMobile) {
       createMobileTopDiceButton();
       createCodeOverlay();
-      
+
       // Hide the editor container for mobile
       const editorContainer = document.getElementById("editor-container");
       if (editorContainer) {
         editorContainer.style.display = "none";
       }
-      
+
       // Show info panel immediately on mobile
       setTimeout(() => {
         showInfoPanel();
@@ -1503,10 +1515,10 @@ async function init() {
 
     // Create updateMidiDeviceList function at the global scope so it can be
     // called from multiple places in the code
-    window.updateMidiDeviceList = function () {
+    window.updateMidiDeviceList = () => {
       // Skip if on mobile or no stats panel
       if (isMobile || !statsPanel || !midiManager) return;
-      
+
       // Clear device container except for the buttons
       while (statsPanel.midi.deviceContainer.children.length > 2) {
         statsPanel.midi.deviceContainer.removeChild(statsPanel.midi.deviceContainer.lastChild);
@@ -1563,7 +1575,6 @@ async function init() {
         statsPanel.midi.deviceContainer.appendChild(deviceButton);
       });
     };
-
 
     // Update the stats panel with MIDI info if supported (desktop only)
     if (midiSupported && statsPanel) {
@@ -1716,19 +1727,23 @@ async function init() {
     }
 
     // Function to move to the next slot after saving
-    window.moveToNextSlot = function (savedSlotInfo) {
+    window.moveToNextSlot = (savedSlotInfo) => {
       if (!window.slotsPanel || !window.moveToNextSlotOnSave) return;
 
       console.log("moveToNextSlot called with:", savedSlotInfo);
 
       // Verify we have valid savedSlotInfo
-      if (!savedSlotInfo || typeof savedSlotInfo !== 'object' ||
-        savedSlotInfo.bank === undefined || savedSlotInfo.slot === undefined) {
+      if (
+        !savedSlotInfo ||
+        typeof savedSlotInfo !== "object" ||
+        savedSlotInfo.bank === undefined ||
+        savedSlotInfo.slot === undefined
+      ) {
         console.error("Invalid savedSlotInfo:", savedSlotInfo);
         // Fall back to current slot
         savedSlotInfo = {
           bank: window.slotsPanel.getBank(),
-          slot: window.slotsPanel.getActiveSlotIndex()
+          slot: window.slotsPanel.getActiveSlotIndex(),
         };
         console.log("Using fallback slot info:", savedSlotInfo);
       }
@@ -1741,13 +1756,13 @@ async function init() {
 
       // Validate inputs and calculate next slot index
       // If values are NaN, default to sensible values
-      if (isNaN(currentBank) || isNaN(currentSlot)) {
+      if (Number.isNaN(currentBank) || Number.isNaN(currentSlot)) {
         console.error("Invalid bank or slot (NaN detected):", currentBank, currentSlot);
         return false;
       }
 
       // Calculate next slot index
-      let nextSlot = (currentSlot + 1) % 16;
+      const nextSlot = (currentSlot + 1) % 16;
       let nextBank = currentBank;
 
       // If we're at the last slot of the current bank, go to the first slot of the next bank
@@ -1833,108 +1848,108 @@ async function init() {
     // Set up size buttons functionality (desktop only)
     if (!isMobile && statsPanel && statsPanel.display && statsPanel.display.sizeButtons) {
       statsPanel.display.sizeButtons.forEach((button) => {
-      button.addEventListener("click", () => {
-        const width = parseInt(button.dataset.width);
-        const height = parseInt(button.dataset.height);
-        const label = button.dataset.label;
+        button.addEventListener("click", () => {
+          const width = Number.parseInt(button.dataset.width);
+          const height = Number.parseInt(button.dataset.height);
+          const label = button.dataset.label;
 
-        if (isNaN(width) || isNaN(height)) {
-          return;
-        }
-
-        // Store the selected size
-        statsPanel.display.selectedSize = { width, height, label };
-
-        // Update the selected size indicator
-        statsPanel.display.selectedSizeIndicator.textContent = `Selected: ${label}`;
-
-        // Enable the breakout button
-        statsPanel.display.breakoutButton.disabled = false;
-        statsPanel.display.breakoutButton.style.opacity = "1";
-        statsPanel.display.breakoutButton.title = `Open breakout window at ${width}×${height}`;
-
-        // Highlight the selected button and unhighlight others
-        statsPanel.display.sizeButtons.forEach((btn) => {
-          if (btn === button) {
-            btn.style.backgroundColor = "rgba(80, 250, 123, 0.3)";
-          } else {
-            btn.style.backgroundColor = "";
+          if (Number.isNaN(width) || Number.isNaN(height)) {
+            return;
           }
+
+          // Store the selected size
+          statsPanel.display.selectedSize = { width, height, label };
+
+          // Update the selected size indicator
+          statsPanel.display.selectedSizeIndicator.textContent = `Selected: ${label}`;
+
+          // Enable the breakout button
+          statsPanel.display.breakoutButton.disabled = false;
+          statsPanel.display.breakoutButton.style.opacity = "1";
+          statsPanel.display.breakoutButton.title = `Open breakout window at ${width}×${height}`;
+
+          // Highlight the selected button and unhighlight others
+          statsPanel.display.sizeButtons.forEach((btn) => {
+            if (btn === button) {
+              btn.style.backgroundColor = "rgba(80, 250, 123, 0.3)";
+            } else {
+              btn.style.backgroundColor = "";
+            }
+          });
         });
       });
-    });
 
       // Set up breakout button functionality (desktop only)
       statsPanel.display.breakoutButton.addEventListener("click", async () => {
-      // If window is already open, close it
-      if (window.breakoutWindow && !window.breakoutWindow.closed) {
-        window.breakoutWindow.close();
-        window.breakoutHydra = null;
-        window.breakoutWindow = null;
+        // If window is already open, close it
+        if (window.breakoutWindow && !window.breakoutWindow.closed) {
+          window.breakoutWindow.close();
+          window.breakoutHydra = null;
+          window.breakoutWindow = null;
 
-        // Reset button
-        statsPanel.display.breakoutButton.textContent = "Breakout View";
-        statsPanel.display.breakoutButton.style.backgroundColor = "";
-        return;
-      }
-
-      // Check if a size is selected
-      if (!statsPanel.display.selectedSize) {
-        showErrorNotification("Please select a window size first");
-        return;
-      }
-
-      const { width, height } = statsPanel.display.selectedSize;
-
-      // Open a new breakout window with the selected size
-      const breakoutWindow = openBreakoutWindow(width, height);
-      if (!breakoutWindow) {
-        return; // Error already shown by openBreakoutWindow
-      }
-
-      // Store reference to window
-      window.breakoutWindow = breakoutWindow;
-
-      try {
-        // Initialize Hydra in the breakout window
-        window.breakoutHydra = await initBreakoutHydra(breakoutWindow, hydra);
-
-        // Update the breakout window title to include size
-        const { label } = statsPanel.display.selectedSize;
-        breakoutWindow.document.title = `HYDRACTRL Breakout - ${label}`;
-
-        // Run the current code in the breakout window
-        await runCode(editor, window.breakoutHydra);
-
-        // Update button text and style
-        statsPanel.display.breakoutButton.textContent = "Close Breakout";
-        statsPanel.display.breakoutButton.style.backgroundColor = "rgba(255, 120, 120, 0.3)";
-
-        // Event handler for window close
-        window.breakoutWindow.addEventListener("beforeunload", () => {
           // Reset button
           statsPanel.display.breakoutButton.textContent = "Breakout View";
           statsPanel.display.breakoutButton.style.backgroundColor = "";
-
-          window.breakoutHydra = null;
-          window.breakoutWindow = null;
-        });
-      } catch (error) {
-        console.error("Error initializing breakout view:", error);
-        showErrorNotification(`Failed to initialize breakout view: ${error.message}`);
-
-        // Clean up on failure
-        if (window.breakoutWindow) {
-          window.breakoutWindow.close();
-          window.breakoutWindow = null;
+          return;
         }
-        window.breakoutHydra = null;
 
-        // Reset button
-        statsPanel.display.breakoutButton.textContent = "Breakout View";
-        statsPanel.display.breakoutButton.style.backgroundColor = "";
-      }
-    });
+        // Check if a size is selected
+        if (!statsPanel.display.selectedSize) {
+          showErrorNotification("Please select a window size first");
+          return;
+        }
+
+        const { width, height } = statsPanel.display.selectedSize;
+
+        // Open a new breakout window with the selected size
+        const breakoutWindow = openBreakoutWindow(width, height);
+        if (!breakoutWindow) {
+          return; // Error already shown by openBreakoutWindow
+        }
+
+        // Store reference to window
+        window.breakoutWindow = breakoutWindow;
+
+        try {
+          // Initialize Hydra in the breakout window
+          window.breakoutHydra = await initBreakoutHydra(breakoutWindow, hydra);
+
+          // Update the breakout window title to include size
+          const { label } = statsPanel.display.selectedSize;
+          breakoutWindow.document.title = `HYDRACTRL Breakout - ${label}`;
+
+          // Run the current code in the breakout window
+          await runCode(editor, window.breakoutHydra);
+
+          // Update button text and style
+          statsPanel.display.breakoutButton.textContent = "Close Breakout";
+          statsPanel.display.breakoutButton.style.backgroundColor = "rgba(255, 120, 120, 0.3)";
+
+          // Event handler for window close
+          window.breakoutWindow.addEventListener("beforeunload", () => {
+            // Reset button
+            statsPanel.display.breakoutButton.textContent = "Breakout View";
+            statsPanel.display.breakoutButton.style.backgroundColor = "";
+
+            window.breakoutHydra = null;
+            window.breakoutWindow = null;
+          });
+        } catch (error) {
+          console.error("Error initializing breakout view:", error);
+          showErrorNotification(`Failed to initialize breakout view: ${error.message}`);
+
+          // Clean up on failure
+          if (window.breakoutWindow) {
+            window.breakoutWindow.close();
+            window.breakoutWindow = null;
+          }
+          window.breakoutHydra = null;
+
+          // Reset button
+          statsPanel.display.breakoutButton.textContent = "Breakout View";
+          statsPanel.display.breakoutButton.style.backgroundColor = "";
+        }
+      });
     }
   } catch (error) {
     console.error("Error initializing application:", error);

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -5,6 +5,21 @@ import { createSlotsPanel } from "../SlotsPanel.js";
 import { createStatsPanel } from "../StatsPanel.js";
 import { createCodeMirrorEditor } from "../utils/CodeMirrorEditor.js";
 import { loadPanelPosition, savePanelPosition } from "../utils/PanelStorage.js";
+import { createEventBus } from "./core/EventBus.js";
+import { createPluginHost } from "./core/PluginHost.js";
+import { createSafeStorage } from "./core/Storage.js";
+import { notify, notifyError, notifySuccess } from "./core/notify.js";
+import { createAudioWatchdogPlugin } from "./plugins/AudioWatchdogPlugin.js";
+import { createUrlSharePlugin, readSketchFromHash } from "./plugins/UrlSharePlugin.js";
+
+// Shared application services: safe storage (never throws on quota errors or
+// in private mode) and the event bus that panels and plugins communicate through.
+const storage = createSafeStorage({
+  onWriteError: () => {
+    notifyError("Storage is full — changes may not persist. Export your banks and clear space.");
+  },
+});
+const events = createEventBus();
 
 // Helper function to debounce events
 function debounce(func, wait) {
@@ -526,6 +541,8 @@ function createInfoPanel() {
   // Define shortcuts
   const shortcuts = [
     { keys: "Ctrl/⌘ + `", action: "Toggle UI visibility" },
+    { keys: "Esc", action: "Bring back hidden UI" },
+    { keys: "Alt/⌥ + U", action: "Copy sketch as shareable URL" },
     { keys: "Ctrl/⌘ + Enter", action: "Run code" },
     { keys: "Ctrl/⌘ + S", action: "Save code" },
     { keys: "Ctrl/⌘ + Y", action: "Toggle Auto Run" },
@@ -876,51 +893,31 @@ async function runCode(editor, hydra) {
   }
 }
 
-// Toggle editor and panel visibility
-function toggleEditor() {
+// Show or hide the editor and all panels. Uses the visibility property to
+// preserve layout. This is the single source of truth for UI visibility —
+// used by the toggle button, the keyboard shortcut and startup restore.
+function setUiVisibility(visible) {
   const editorContainer = document.getElementById("editor-container");
   const statsPanelElement = document.querySelector(".stats-panel");
   const slotsPanelElement = document.querySelector(".slots-panel");
   const docPanelElement = document.querySelector(".doc-panel");
   const xyPadPanelElement = document.querySelector(".xy-pad-panel");
 
-  // Get visibility states from localStorage
-  const isVisible = localStorage.getItem("hydractrl-ui-visible") !== "false";
-  const xyPadVisible = localStorage.getItem("hydractrl-xy-pad-visible") === "true";
+  const xyPadVisible = storage.get("hydractrl-xy-pad-visible") === "true";
+  const visibility = visible ? "visible" : "hidden";
 
-  if (isVisible) {
-    // Hide the editor and panels using visibility property to preserve layout
-    editorContainer.style.visibility = "hidden";
+  if (editorContainer) editorContainer.style.visibility = visibility;
+  if (statsPanelElement) statsPanelElement.style.visibility = visibility;
+  if (slotsPanelElement) slotsPanelElement.style.visibility = visibility;
+  if (docPanelElement) docPanelElement.style.visibility = visibility;
+  // Only touch the XY pad if it's supposed to be visible
+  if (xyPadPanelElement && xyPadVisible) xyPadPanelElement.style.visibility = visibility;
 
-    // Hide all panels if they exist
-    if (statsPanelElement) statsPanelElement.style.visibility = "hidden";
-    if (slotsPanelElement) slotsPanelElement.style.visibility = "hidden";
-    if (docPanelElement) docPanelElement.style.visibility = "hidden";
-    // Only hide XY pad if it's supposed to be visible
-    if (xyPadPanelElement && xyPadVisible) xyPadPanelElement.style.visibility = "hidden";
+  document.body.classList.toggle("ui-hidden", !visible);
+  storage.set("hydractrl-ui-visible", visible ? "true" : "false");
+  events.emit("ui:visibility", { visible });
 
-    // Add a CSS class to the body to indicate hidden UI
-    document.body.classList.add("ui-hidden");
-
-    // Store the new visibility state
-    localStorage.setItem("hydractrl-ui-visible", "false");
-  } else {
-    // Show the editor and panels
-    editorContainer.style.visibility = "visible";
-
-    // Show all panels if they exist
-    if (statsPanelElement) statsPanelElement.style.visibility = "visible";
-    if (slotsPanelElement) slotsPanelElement.style.visibility = "visible";
-    if (docPanelElement) docPanelElement.style.visibility = "visible";
-    // Only show XY pad if it's supposed to be visible
-    if (xyPadPanelElement && xyPadVisible) xyPadPanelElement.style.visibility = "visible";
-
-    // Remove the hidden UI class
-    document.body.classList.remove("ui-hidden");
-
-    // Store the new visibility state
-    localStorage.setItem("hydractrl-ui-visible", "true");
-
+  if (visible) {
     // Focus the editor and trigger resize after showing
     setTimeout(() => {
       if (window._editorProxy) {
@@ -932,10 +929,16 @@ function toggleEditor() {
   }
 }
 
+// Toggle editor and panel visibility
+function toggleEditor() {
+  const isVisible = storage.get("hydractrl-ui-visible") !== "false";
+  setUiVisibility(!isVisible);
+}
+
 // Save code to local storage
 function saveCode(editor) {
   const code = editor.state.doc.toString();
-  localStorage.setItem("hydractrl-code", code);
+  storage.set("hydractrl-code", code);
 }
 
 // Load code from local storage
@@ -999,14 +1002,15 @@ async function importDefaultScenesIfEmpty() {
                 // Decode base64 code and handle non-Latin1 characters
                 const decodedCode = decodeURIComponent(atob(slot.code));
 
-                // Save to localStorage using the same key format as SlotsPanel
+                // Save using the same key format as SlotsPanel; storage.set is
+                // quota-safe so a full store can't abort the whole import
                 const storageKey = getStorageKey(bankIndex, slot.slotIndex);
-                localStorage.setItem(storageKey, decodedCode);
+                storage.set(storageKey, decodedCode);
 
                 // Save thumbnail if available in the imported data
                 if (slot.thumbnail) {
-                  localStorage.setItem(`${storageKey}-thumbnail`, slot.thumbnail);
-                  localStorage.setItem(`${storageKey}-thumbnail-timestamp`, Date.now());
+                  storage.set(`${storageKey}-thumbnail`, slot.thumbnail);
+                  storage.set(`${storageKey}-thumbnail-timestamp`, Date.now());
                 }
               } catch (decodeError) {
                 console.error("Error decoding slot data:", decodeError);
@@ -1016,20 +1020,7 @@ async function importDefaultScenesIfEmpty() {
         }
       });
 
-      // Show notification
-      const notification = document.createElement("div");
-      notification.className = "saved-notification";
-      notification.textContent = "Default scenes imported successfully!";
-      document.body.appendChild(notification);
-
-      setTimeout(() => {
-        notification.classList.add("fade-out");
-        setTimeout(() => {
-          if (notification.parentNode) {
-            document.body.removeChild(notification);
-          }
-        }, 500);
-      }, 2000);
+      notify("Default scenes imported successfully!");
 
       return true;
     } catch (error) {
@@ -1193,25 +1184,11 @@ async function init() {
     const editor = initEditor(); // No longer async
     const hydra = await initHydra();
 
-    // Apply UI visibility state from localStorage right after panels are created
+    // Apply UI visibility state from localStorage right after panels are created.
+    // Only applies when explicitly hidden, so first-time users see the UI.
     const applyUiVisibility = () => {
-      const isVisible = localStorage.getItem("hydractrl-ui-visible");
-
-      // Only apply if explicitly set to false (hidden)
-      if (isVisible === "false") {
-        const editorContainer = document.getElementById("editor-container");
-        const statsPanelElement = document.querySelector(".stats-panel");
-        const slotsPanelElement = document.querySelector(".slots-panel");
-        const docPanelElement = document.querySelector(".doc-panel");
-
-        // Hide all UI elements using visibility to preserve layout
-        if (editorContainer) editorContainer.style.visibility = "hidden";
-        if (statsPanelElement) statsPanelElement.style.visibility = "hidden";
-        if (slotsPanelElement) statsPanelElement.style.visibility = "hidden";
-        if (docPanelElement) docPanelElement.style.visibility = "hidden";
-
-        // Add a CSS class to the body to indicate hidden UI
-        document.body.classList.add("ui-hidden");
+      if (storage.get("hydractrl-ui-visible") === "false") {
+        setUiVisibility(false);
       }
     };
 
@@ -1289,19 +1266,7 @@ async function init() {
         }
       } else {
         // Show temporary "Saved!" notification only if not using slots
-        const savedNotification = document.createElement("div");
-        savedNotification.className = "saved-notification";
-        savedNotification.textContent = "Saved!";
-        document.body.appendChild(savedNotification);
-
-        setTimeout(() => {
-          savedNotification.classList.add("fade-out");
-          setTimeout(() => {
-            if (savedNotification.parentNode) {
-              document.body.removeChild(savedNotification);
-            }
-          }, 500);
-        }, 1500);
+        notify("Saved!", { duration: 1500 });
       }
 
       editor.focus(); // Return focus to editor after saving
@@ -1343,13 +1308,22 @@ async function init() {
         editor.focus();
       }
 
-      // Ctrl/Cmd+` (backtick) to toggle editor visibility
-      if (e.key === "`" && (e.ctrlKey || e.metaKey)) {
+      // Ctrl/Cmd+` (backtick) to toggle editor visibility.
+      // Match on the physical key (e.code) so this works on international
+      // keyboard layouts where "`" needs a modifier or doesn't exist (issue #7).
+      if (e.code === "Backquote" && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         toggleEditor();
       }
 
-      if ((e.altKey || e.optKey) && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+      // Escape always brings the UI back when it is hidden, so there is a
+      // layout-independent way to recover from a hidden UI (issue #7).
+      if (e.key === "Escape" && document.body.classList.contains("ui-hidden")) {
+        e.preventDefault();
+        setUiVisibility(true);
+      }
+
+      if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
         // Hexadecimal keys 0-F (physical keys) to select slots 0-15
         let slotIndex = -1;
         const keyCode = e.code; // Use e.code for physical key identification
@@ -1391,7 +1365,7 @@ async function init() {
       }
 
       // Alt+Left/Right arrow keys to cycle between banks (only when no MIDI device is connected)
-      if ((e.altKey || e.optKey) && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+      if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
         if (e.code === "ArrowLeft" && window.slotsPanel && window.slotsPanel.cycleBank) {
           /* Use e.code */
           // Check if MIDI device is connected
@@ -1434,8 +1408,17 @@ async function init() {
       }
     });
 
-    // Load saved code if available
-    loadCode(editor);
+    // A sketch shared via URL (#sketch=...) takes precedence over saved code
+    // and is deliberately NOT persisted — the user's banks stay untouched
+    // unless they explicitly save (issue #5).
+    const urlSketch = readSketchFromHash(window.location.hash);
+    if (urlSketch !== null) {
+      editor.dispatch({ changes: { insert: urlSketch } });
+      notify("Loaded sketch from URL (not saved to your banks)");
+    } else {
+      // Load saved code if available
+      loadCode(editor);
+    }
 
     // Run initial code
     await runCodeOnAllInstances(editor, hydra);
@@ -1467,7 +1450,10 @@ async function init() {
     await importDefaultScenesIfEmpty();
 
     // Create the slots panel (always shown, but positioned differently on mobile)
-    const slotsPanel = createSlotsPanel(editor, hydra, runCode, isMobile);
+    const slotsPanel = createSlotsPanel(editor, hydra, runCode, isMobile, {
+      // Don't let slot 0 overwrite a sketch that was loaded from the URL
+      keepEditorContent: urlSketch !== null,
+    });
 
     if (!isMobile) {
       // Initialize MIDI support with the slots panel (desktop only)
@@ -1612,21 +1598,7 @@ async function init() {
           // Update UI
           window.updateMidiDeviceList();
 
-          // Show temporary notification
-          const notification = document.createElement("div");
-          notification.className = "saved-notification";
-          notification.style.backgroundColor = "rgba(80, 250, 123, 0.8)";
-          notification.textContent = `Synced nanoPAD Scene ${currentBank + 1} with Bank ${currentBank + 1}`;
-          document.body.appendChild(notification);
-
-          setTimeout(() => {
-            notification.classList.add("fade-out");
-            setTimeout(() => {
-              if (notification.parentNode) {
-                document.body.removeChild(notification);
-              }
-            }, 500);
-          }, 2000);
+          notifySuccess(`Synced nanoPAD Scene ${currentBank + 1} with Bank ${currentBank + 1}`);
         }
       });
 
@@ -1644,21 +1616,7 @@ async function init() {
           if (confirm("Reset MIDI mapping to defaults?")) {
             window.midiManager.resetToDefaultMapping();
 
-            // Show temporary notification
-            const notification = document.createElement("div");
-            notification.className = "saved-notification";
-            notification.style.backgroundColor = "rgba(255, 120, 120, 0.8)";
-            notification.textContent = "MIDI mapping reset to defaults";
-            document.body.appendChild(notification);
-
-            setTimeout(() => {
-              notification.classList.add("fade-out");
-              setTimeout(() => {
-                if (notification.parentNode) {
-                  document.body.removeChild(notification);
-                }
-              }, 500);
-            }, 2000);
+            notifyError("MIDI mapping reset to defaults", { duration: 2000 });
           }
         }
       });
@@ -1776,20 +1734,7 @@ async function init() {
       if (nextBank < currentBank) {
         console.log("Wrapping around to first bank, showing warning");
         // We're going back to bank 0 from bank 3, show a warning popup
-        const fullNotification = document.createElement("div");
-        fullNotification.className = "saved-notification";
-        fullNotification.style.backgroundColor = "var(--color-error)";
-        fullNotification.textContent = "All banks full! Can't advance further.";
-        document.body.appendChild(fullNotification);
-
-        setTimeout(() => {
-          fullNotification.classList.add("fade-out");
-          setTimeout(() => {
-            if (fullNotification.parentNode) {
-              document.body.removeChild(fullNotification);
-            }
-          }, 500);
-        }, 1500);
+        notifyError("All banks full! Can't advance further.", { duration: 1500 });
 
         // Don't advance to next slot in this case
         return false;
@@ -1836,6 +1781,38 @@ async function init() {
     window.showInfoPanel = showInfoPanel; // Expose info panel functions
     window.hideInfoPanel = hideInfoPanel;
     window.toggleEditor = toggleEditor; // Expose toggle editor function
+
+    // Set up the plugin system. Plugins receive a stable context object and
+    // communicate with the rest of the app through the event bus, so they
+    // can be added or removed without touching the core (see docs/PLUGINS.md).
+    const pluginContext = {
+      hydra,
+      editor,
+      runCode: () => runCodeOnAllInstances(editor, hydra),
+      events,
+      storage,
+      notify,
+      getPanels: () => ({
+        stats: statsPanel,
+        slots: slotsPanel,
+        doc: docPanel,
+        xyPad: window.xyPadPanel,
+      }),
+    };
+    const pluginHost = createPluginHost(pluginContext);
+    pluginHost.register(createUrlSharePlugin());
+    pluginHost.register(createAudioWatchdogPlugin());
+    pluginHost.init();
+
+    // Public extension point: external code (console, userscripts, future
+    // built-ins) can register plugins via window.hydractrl.
+    window.hydractrl = {
+      version: "0.0.1",
+      events,
+      storage,
+      plugins: pluginHost,
+      registerPlugin: (plugin) => pluginHost.register(plugin),
+    };
 
     // Check if we should show the info panel on startup (desktop only, mobile shows it automatically)
     if (!isMobile && localStorage.getItem("hydractrl-show-info-on-startup") !== "false") {
@@ -1953,6 +1930,11 @@ async function init() {
     }
   } catch (error) {
     console.error("Error initializing application:", error);
+    // Never fail silently into a black screen: tell the user what happened.
+    showErrorNotification(
+      `HYDRACTRL failed to start: ${error.message || error}. ` +
+        "Check the console for details (WebGL support is required).",
+    );
   }
 }
 

--- a/src/client/plugins/AudioWatchdogPlugin.js
+++ b/src/client/plugins/AudioWatchdogPlugin.js
@@ -1,0 +1,138 @@
+/**
+ * AudioWatchdogPlugin - diagnose and recover audio FFT dropouts (GitHub issue #1).
+ *
+ * a.fft has been observed to silently cut out mid-performance with no console
+ * errors. The most common cause is the browser suspending the AudioContext
+ * (tab backgrounding, device switch, OS-level interruptions). This watchdog:
+ *
+ *  - periodically checks the AudioContext state and attempts resume() when
+ *    it is suspended (also re-tries on the next user gesture, which browsers
+ *    require for resume in some cases);
+ *  - detects when the FFT flatlines after having been active, and logs a
+ *    timestamped diagnostic dump so the failure is no longer silent;
+ *  - emits "audio:suspended", "audio:flatline" and "audio:recovered" events
+ *    that other plugins/panels can react to.
+ */
+
+/** Number of consecutive silent checks before we call it a flatline. */
+const FLATLINE_THRESHOLD = 4;
+const EPSILON = 0.0001;
+
+/** Pure helper: is an FFT frame effectively silent? Exported for tests. */
+export function isFlatFrame(fft, epsilon = EPSILON) {
+  if (!fft || typeof fft.length !== "number" || fft.length === 0) return true;
+  let sum = 0;
+  for (let i = 0; i < fft.length; i++) {
+    sum += Math.abs(fft[i] || 0);
+  }
+  return sum <= epsilon;
+}
+
+export function createAudioWatchdogPlugin(options = {}) {
+  const intervalMs = options.intervalMs || 3000;
+
+  return {
+    id: "audio-watchdog",
+    name: "Audio Watchdog",
+    description: "Detects a.fft dropouts, logs diagnostics and auto-resumes the AudioContext",
+
+    setup(ctx) {
+      let flatChecks = 0;
+      let everActive = false;
+      let flatlineReported = false;
+
+      function getAudio() {
+        // hydra-synth (makeGlobal) exposes the audio analyser as window.a
+        return typeof window !== "undefined" ? window.a : null;
+      }
+
+      function resumeContext(context, reason) {
+        if (!context || typeof context.resume !== "function") return;
+        context
+          .resume()
+          .then(() => {
+            console.warn(`[audio-watchdog] AudioContext resumed (${reason})`);
+          })
+          .catch((error) => {
+            console.warn(`[audio-watchdog] AudioContext resume failed (${reason}):`, error);
+          });
+      }
+
+      // Browsers only allow resume() from a user gesture in some situations,
+      // so also retry on the next interaction whenever we saw a suspension.
+      let gestureRetryArmed = false;
+      function armGestureRetry(context) {
+        if (gestureRetryArmed) return;
+        gestureRetryArmed = true;
+        const onGesture = () => {
+          gestureRetryArmed = false;
+          document.removeEventListener("pointerdown", onGesture);
+          document.removeEventListener("keydown", onGesture);
+          if (context.state === "suspended") {
+            resumeContext(context, "user gesture");
+          }
+        };
+        document.addEventListener("pointerdown", onGesture);
+        document.addEventListener("keydown", onGesture);
+      }
+
+      function check() {
+        try {
+          const audio = getAudio();
+          if (!audio || !audio.fft) return;
+
+          const context = audio.context;
+          if (context && context.state === "suspended") {
+            console.warn(
+              `[audio-watchdog] ${new Date().toISOString()} AudioContext is suspended — attempting resume`,
+            );
+            ctx.events.emit("audio:suspended", { at: Date.now() });
+            resumeContext(context, "watchdog");
+            armGestureRetry(context);
+          }
+
+          if (isFlatFrame(audio.fft)) {
+            if (!everActive) return; // never had signal yet; nothing to report
+            flatChecks++;
+            if (flatChecks === FLATLINE_THRESHOLD && !flatlineReported) {
+              flatlineReported = true;
+              console.warn(
+                `[audio-watchdog] ${new Date().toISOString()} a.fft flatlined after being active.`,
+                {
+                  contextState: context ? context.state : "no-context",
+                  fft: Array.from(audio.fft),
+                  bins: audio.bins,
+                },
+              );
+              ctx.events.emit("audio:flatline", { at: Date.now() });
+              // A suspended/interrupted context is the usual culprit; try a nudge.
+              if (context) {
+                resumeContext(context, "flatline recovery");
+                armGestureRetry(context);
+              }
+            }
+          } else {
+            if (flatlineReported) {
+              console.warn(`[audio-watchdog] ${new Date().toISOString()} a.fft signal recovered.`);
+              ctx.events.emit("audio:recovered", { at: Date.now() });
+            }
+            everActive = true;
+            flatChecks = 0;
+            flatlineReported = false;
+          }
+        } catch (error) {
+          console.error("[audio-watchdog] check failed:", error);
+        }
+      }
+
+      const timer = setInterval(check, intervalMs);
+
+      return {
+        api: { check },
+        dispose() {
+          clearInterval(timer);
+        },
+      };
+    },
+  };
+}

--- a/src/client/plugins/AudioWatchdogPlugin.test.js
+++ b/src/client/plugins/AudioWatchdogPlugin.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { isFlatFrame } from "./AudioWatchdogPlugin.js";
+
+describe("isFlatFrame", () => {
+  test("treats missing or empty FFT data as flat", () => {
+    expect(isFlatFrame(null)).toBe(true);
+    expect(isFlatFrame(undefined)).toBe(true);
+    expect(isFlatFrame([])).toBe(true);
+    expect(isFlatFrame({})).toBe(true);
+  });
+
+  test("detects silence", () => {
+    expect(isFlatFrame([0, 0, 0, 0, 0, 0])).toBe(true);
+    expect(isFlatFrame(new Float32Array(6))).toBe(true);
+  });
+
+  test("detects live signal", () => {
+    expect(isFlatFrame([0.2, 0.05, 0.4, 0, 0, 0.01])).toBe(false);
+    expect(isFlatFrame(new Float32Array([0, 0, 0.5, 0, 0, 0]))).toBe(false);
+  });
+
+  test("ignores sub-epsilon noise", () => {
+    expect(isFlatFrame([0.00001, 0, 0, 0, 0, 0])).toBe(true);
+  });
+
+  test("handles NaN/undefined bins defensively", () => {
+    const withHoles = [0.3, undefined, Number.NaN, 0, 0, 0];
+    expect(isFlatFrame(withHoles)).toBe(false);
+  });
+
+  test("respects a custom epsilon", () => {
+    expect(isFlatFrame([0.01, 0, 0, 0], 0.1)).toBe(true);
+    expect(isFlatFrame([0.2, 0, 0, 0], 0.1)).toBe(false);
+  });
+});

--- a/src/client/plugins/UrlSharePlugin.js
+++ b/src/client/plugins/UrlSharePlugin.js
@@ -1,0 +1,145 @@
+/**
+ * UrlSharePlugin - share sketches as URLs (GitHub issue #5).
+ *
+ * Alt/Opt+U copies a link with the current sketch encoded in the URL fragment
+ * (e.g. https://host/#sketch=...). Opening such a link loads and runs the
+ * sketch WITHOUT touching localStorage slots — nothing is persisted unless
+ * the user explicitly saves.
+ *
+ * The codec functions are pure and exported for tests.
+ */
+
+const SKETCH_PARAM = "sketch";
+
+/**
+ * Encode sketch code into a URL-safe base64 string.
+ * Uses encodeURIComponent before btoa so non-Latin1 characters survive,
+ * matching the convention used by the bank export format.
+ */
+export function encodeSketch(code) {
+  if (typeof code !== "string" || code.length === 0) return null;
+  const base64 = btoa(encodeURIComponent(code));
+  // base64url: keep the fragment clean and safe to paste anywhere
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Decode a sketch string produced by encodeSketch.
+ * @returns {string|null} The code, or null if the payload is invalid.
+ */
+export function decodeSketch(encoded) {
+  if (typeof encoded !== "string" || encoded.length === 0) return null;
+  try {
+    let base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    while (base64.length % 4 !== 0) {
+      base64 += "=";
+    }
+    return decodeURIComponent(atob(base64));
+  } catch (_error) {
+    return null;
+  }
+}
+
+/**
+ * Extract sketch code from a URL fragment like "#sketch=..." .
+ * @param {string} hash - window.location.hash (leading "#" optional).
+ * @returns {string|null}
+ */
+export function readSketchFromHash(hash) {
+  if (typeof hash !== "string") return null;
+  const fragment = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!fragment) return null;
+  const params = new URLSearchParams(fragment);
+  const encoded = params.get(SKETCH_PARAM);
+  if (!encoded) return null;
+  return decodeSketch(encoded);
+}
+
+/** Build a shareable URL for the given code, based on the current location. */
+export function buildShareUrl(code, location) {
+  const encoded = encodeSketch(code);
+  if (!encoded) return null;
+  return `${location.origin}${location.pathname}#${SKETCH_PARAM}=${encoded}`;
+}
+
+async function copyToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+  // Fallback for insecure contexts
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const ok = document.execCommand("copy");
+  textarea.remove();
+  return ok;
+}
+
+export function createUrlSharePlugin() {
+  return {
+    id: "url-share",
+    name: "URL Sketch Sharing",
+    description: "Copy the current sketch as a shareable link (Alt/Opt+U)",
+
+    setup(ctx) {
+      async function copyLink() {
+        const code = ctx.editor.state.doc.toString();
+        const url = buildShareUrl(code, window.location);
+        if (!url) {
+          ctx.notify("Nothing to share — the sketch is empty", { type: "error" });
+          return null;
+        }
+        try {
+          await copyToClipboard(url);
+          ctx.notify("Sketch link copied to clipboard!", { type: "success" });
+          ctx.events.emit("sketch:shared", { url });
+          return url;
+        } catch (error) {
+          console.error("UrlSharePlugin: clipboard write failed:", error);
+          ctx.notify("Could not copy link (clipboard unavailable)", { type: "error" });
+          return null;
+        }
+      }
+
+      function loadFromHash(hash) {
+        const code = readSketchFromHash(hash);
+        if (code === null) return false;
+        ctx.editor.dispatch({ changes: { insert: code } });
+        ctx.runCode();
+        ctx.notify("Loaded sketch from URL (not saved to your banks)");
+        ctx.events.emit("sketch:loaded-from-url", {});
+        return true;
+      }
+
+      const onKeyDown = (event) => {
+        if (
+          event.altKey &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.shiftKey &&
+          event.code === "KeyU"
+        ) {
+          event.preventDefault();
+          copyLink();
+        }
+      };
+      document.addEventListener("keydown", onKeyDown);
+
+      // Live-load when the user pastes a sketch URL into the address bar
+      const onHashChange = () => loadFromHash(window.location.hash);
+      window.addEventListener("hashchange", onHashChange);
+
+      return {
+        api: { copyLink, loadFromHash },
+        dispose() {
+          document.removeEventListener("keydown", onKeyDown);
+          window.removeEventListener("hashchange", onHashChange);
+        },
+      };
+    },
+  };
+}

--- a/src/client/plugins/UrlSharePlugin.test.js
+++ b/src/client/plugins/UrlSharePlugin.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { buildShareUrl, decodeSketch, encodeSketch, readSketchFromHash } from "./UrlSharePlugin.js";
+
+const SAMPLE_SKETCH = `osc(10, 0.1, 1.2)
+  .color(0.5, 0.1, 0.9)
+  .rotate(0, 0.1)
+  .out()
+`;
+
+describe("sketch URL codec", () => {
+  test("round-trips plain sketches", () => {
+    const encoded = encodeSketch(SAMPLE_SKETCH);
+    expect(decodeSketch(encoded)).toBe(SAMPLE_SKETCH);
+  });
+
+  test("round-trips non-Latin1 characters", () => {
+    const code = "// ünïcødé — 日本語 🎛️\nosc(4).out()";
+    expect(decodeSketch(encodeSketch(code))).toBe(code);
+  });
+
+  test("produces URL-safe output (no +, / or =)", () => {
+    // This input is chosen to produce +, / and padding in plain base64
+    const code = "~~~???>>>ab";
+    const encoded = encodeSketch(code);
+    expect(encoded).not.toMatch(/[+/=]/);
+    expect(decodeSketch(encoded)).toBe(code);
+  });
+
+  test("rejects empty or non-string input", () => {
+    expect(encodeSketch("")).toBe(null);
+    expect(encodeSketch(undefined)).toBe(null);
+    expect(decodeSketch("")).toBe(null);
+    expect(decodeSketch(undefined)).toBe(null);
+  });
+
+  test("decodeSketch returns null for garbage instead of throwing", () => {
+    expect(decodeSketch("!!not-base64!!")).toBe(null);
+    expect(decodeSketch("%%%")).toBe(null);
+  });
+});
+
+describe("readSketchFromHash", () => {
+  test("extracts a sketch from a location hash", () => {
+    const encoded = encodeSketch(SAMPLE_SKETCH);
+    expect(readSketchFromHash(`#sketch=${encoded}`)).toBe(SAMPLE_SKETCH);
+    // Leading "#" is optional
+    expect(readSketchFromHash(`sketch=${encoded}`)).toBe(SAMPLE_SKETCH);
+  });
+
+  test("returns null when there is no sketch parameter", () => {
+    expect(readSketchFromHash("")).toBe(null);
+    expect(readSketchFromHash("#")).toBe(null);
+    expect(readSketchFromHash("#other=1")).toBe(null);
+    expect(readSketchFromHash(undefined)).toBe(null);
+  });
+
+  test("returns null for a corrupt payload", () => {
+    expect(readSketchFromHash("#sketch=!!bad!!")).toBe(null);
+  });
+});
+
+describe("buildShareUrl", () => {
+  test("builds a link from the current location", () => {
+    const location = { origin: "https://hydractrl.example", pathname: "/" };
+    const url = buildShareUrl("osc().out()", location);
+
+    expect(url.startsWith("https://hydractrl.example/#sketch=")).toBe(true);
+    const hash = url.slice(url.indexOf("#"));
+    expect(readSketchFromHash(hash)).toBe("osc().out()");
+  });
+
+  test("returns null for an empty sketch", () => {
+    const location = { origin: "https://hydractrl.example", pathname: "/" };
+    expect(buildShareUrl("", location)).toBe(null);
+  });
+});

--- a/src/data/hydra-functions.json
+++ b/src/data/hydra-functions.json
@@ -8,12 +8,37 @@
     "color": {
       "title": "Color",
       "color": "#CCFF99",
-      "functions": ["brightness", "contrast", "color", "colorama", "invert", "luma", "posterize", "saturate", "thresh", "hue", "r", "g", "b"]
+      "functions": [
+        "brightness",
+        "contrast",
+        "color",
+        "colorama",
+        "invert",
+        "luma",
+        "posterize",
+        "saturate",
+        "thresh",
+        "hue",
+        "r",
+        "g",
+        "b"
+      ]
     },
     "geometry": {
       "title": "Geometry",
       "color": "#FFEE99",
-      "functions": ["kaleid", "pixelate", "repeat", "repeatX", "repeatY", "rotate", "scale", "scroll", "scrollX", "scrollY"]
+      "functions": [
+        "kaleid",
+        "pixelate",
+        "repeat",
+        "repeatX",
+        "repeatY",
+        "rotate",
+        "scale",
+        "scroll",
+        "scrollX",
+        "scrollY"
+      ]
     },
     "blend": {
       "title": "Blend",
@@ -23,7 +48,19 @@
     "modulate": {
       "title": "Modulate",
       "color": "#99ffee",
-      "functions": ["modulate", "modulateHue", "modulateKaleid", "modulatePixelate", "modulateRepeat", "modulateRepeatX", "modulateRepeatY", "modulateRotate", "modulateScale", "modulateScrollX", "modulateScrollY"]
+      "functions": [
+        "modulate",
+        "modulateHue",
+        "modulateKaleid",
+        "modulatePixelate",
+        "modulateRepeat",
+        "modulateRepeatX",
+        "modulateRepeatY",
+        "modulateRotate",
+        "modulateScale",
+        "modulateScrollX",
+        "modulateScrollY"
+      ]
     },
     "external": {
       "title": "External",
@@ -33,7 +70,19 @@
     "settings": {
       "title": "Settings",
       "color": "#aa99ff",
-      "functions": ["render", "update", "setResolution", "hush", "setFunction", "speed", "bpm", "width", "height", "time", "mouse"]
+      "functions": [
+        "render",
+        "update",
+        "setResolution",
+        "hush",
+        "setFunction",
+        "speed",
+        "bpm",
+        "width",
+        "height",
+        "time",
+        "mouse"
+      ]
     },
     "array": {
       "title": "Array",
@@ -93,9 +142,7 @@
     "gradient": {
       "description": "Generate a color gradient",
       "example": "gradient(speed = 0).out()",
-      "params": [
-        { "name": "speed", "default": "0", "description": "Speed of gradient animation" }
-      ],
+      "params": [{ "name": "speed", "default": "0", "description": "Speed of gradient animation" }],
       "syntaxType": "source",
       "returnType": "texture"
     },
@@ -153,18 +200,14 @@
     "colorama": {
       "description": "Shift HSV values",
       "example": "osc().colorama(amount = 0.005).out()",
-      "params": [
-        { "name": "amount", "default": "0.005", "description": "Amount of color shift" }
-      ],
+      "params": [{ "name": "amount", "default": "0.005", "description": "Amount of color shift" }],
       "syntaxType": "method",
       "returnType": "texture"
     },
     "invert": {
       "description": "Invert colors",
       "example": "osc().invert(amount = 1).out()",
-      "params": [
-        { "name": "amount", "default": "1", "description": "Amount of color inversion" }
-      ],
+      "params": [{ "name": "amount", "default": "1", "description": "Amount of color inversion" }],
       "syntaxType": "method",
       "returnType": "texture"
     },
@@ -191,9 +234,7 @@
     "hue": {
       "description": "Adjust hue",
       "example": "osc().hue(amount = 0.4).out()",
-      "params": [
-        { "name": "amount", "default": "0.4", "description": "Amount of hue adjustment" }
-      ],
+      "params": [{ "name": "amount", "default": "0.4", "description": "Amount of hue adjustment" }],
       "syntaxType": "method",
       "returnType": "texture"
     },
@@ -375,27 +416,21 @@
     "diff": {
       "description": "Return absolute difference between textures",
       "example": "osc().diff(texture).out()",
-      "params": [
-        { "name": "texture", "description": "Texture to diff with" }
-      ],
+      "params": [{ "name": "texture", "description": "Texture to diff with" }],
       "syntaxType": "method",
       "returnType": "texture"
     },
     "layer": {
       "description": "Layer textures",
       "example": "osc().layer( texture ).out()",
-      "params": [
-        { "name": "texture", "description": "Texture to layer" }
-      ],
+      "params": [{ "name": "texture", "description": "Texture to layer" }],
       "syntaxType": "method",
       "returnType": "texture"
     },
     "mask": {
       "description": "Use one texture as alpha mask for another",
       "example": "osc().mask(texture).out()",
-      "params": [
-        { "name": "texture", "description": "Texture to use as mask" }
-      ],
+      "params": [{ "name": "texture", "description": "Texture to use as mask" }],
       "syntaxType": "method",
       "returnType": "texture"
     },
@@ -542,9 +577,7 @@
     "initCam": {
       "description": "Initialize webcam as an input source (s0, s1, etc.)",
       "example": "initCam()",
-      "params": [
-        { "name": "index", "default": "0", "description": "Camera index" }
-      ],
+      "params": [{ "name": "index", "default": "0", "description": "Camera index" }],
       "syntaxType": "function",
       "returnType": "void"
     },
@@ -558,27 +591,21 @@
     "initVideo": {
       "description": "Initialize video from URL as an input source",
       "example": "initVideo(url)",
-      "params": [
-        { "name": "url", "description": "Video URL" }
-      ],
+      "params": [{ "name": "url", "description": "Video URL" }],
       "syntaxType": "function",
       "returnType": "void"
     },
     "init": {
       "description": "Initialize video from URL as an input source",
       "example": "init({ src: canvas })",
-      "params": [
-        { "name": "options", "description": "Initialization options" }
-      ],
+      "params": [{ "name": "options", "description": "Initialization options" }],
       "syntaxType": "function",
       "returnType": "void"
     },
     "initImage": {
       "description": "Initialize image from URL as an input source",
       "example": "initImage(url)",
-      "params": [
-        { "name": "url", "description": "Image URL" }
-      ],
+      "params": [{ "name": "url", "description": "Image URL" }],
       "syntaxType": "function",
       "returnType": "void"
     },
@@ -595,7 +622,11 @@
       "description": "Render all output buffers",
       "example": "render(buffer = o0)",
       "params": [
-        { "name": "buffer", "default": "o0", "description": "Buffer to output to main display (o0, o1, o2, o3)" }
+        {
+          "name": "buffer",
+          "default": "o0",
+          "description": "Buffer to output to main display (o0, o1, o2, o3)"
+        }
       ],
       "syntaxType": "function",
       "returnType": "void"
@@ -627,27 +658,21 @@
     "setFunction": {
       "description": "Register a function in hydra",
       "example": "setFunction(options) - https://hydra.ojack.xyz/api/#functions/setFunction/0",
-      "params": [
-        { "name": "options", "description": "Options object" }
-      ],
+      "params": [{ "name": "options", "description": "Options object" }],
       "syntaxType": "function",
       "returnType": "void"
     },
     "speed": {
       "description": "Set speed of time",
       "example": "speed = 1",
-      "params": [
-        { "name": "speed", "description": "Speed of time" }
-      ],
+      "params": [{ "name": "speed", "description": "Speed of time" }],
       "syntaxType": "global",
       "returnType": "void"
     },
     "bpm": {
       "description": "Set BPM of time",
       "example": "bpm = 120",
-      "params": [
-        { "name": "bpm", "description": "BPM of time" }
-      ],
+      "params": [{ "name": "bpm", "description": "BPM of time" }],
       "syntaxType": "global",
       "returnType": "void"
     },
@@ -682,36 +707,28 @@
     "fast": {
       "description": "Fast array",
       "example": "fast( speed = 1 )",
-      "params": [
-        { "name": "speed", "default": "1", "description": "Speed of array" }
-      ],
+      "params": [{ "name": "speed", "default": "1", "description": "Speed of array" }],
       "syntaxType": "method",
       "returnType": "array"
     },
     "smooth": {
       "description": "Smooth array",
       "example": "smooth( speed = 1 )",
-      "params": [
-        { "name": "speed", "default": "1", "description": "Speed of array" }
-      ],
+      "params": [{ "name": "speed", "default": "1", "description": "Speed of array" }],
       "syntaxType": "method",
       "returnType": "array"
     },
     "ease": {
       "description": "Ease array",
       "example": "ease( ease = 'linear' )",
-      "params": [
-        { "name": "ease", "default": "linear", "description": "Easing function" }
-      ],
+      "params": [{ "name": "ease", "default": "linear", "description": "Easing function" }],
       "syntaxType": "method",
       "returnType": "array"
     },
     "offset": {
       "description": "Offset array",
       "example": "offset( offset = 0.5 )",
-      "params": [
-        { "name": "offset", "default": "0.5", "description": "Offset of array" }
-      ],
+      "params": [{ "name": "offset", "default": "0.5", "description": "Offset of array" }],
       "syntaxType": "method",
       "returnType": "array"
     },
@@ -735,27 +752,21 @@
     "setSmooth": {
       "description": "Set smoothness of FFT",
       "example": "a.setSmooth( smooth = 0.4 )",
-      "params": [
-        { "name": "smooth", "default": "0.4", "description": "Smoothness of FFT" }
-      ],
+      "params": [{ "name": "smooth", "default": "0.4", "description": "Smoothness of FFT" }],
       "syntaxType": "method",
       "returnType": "void"
     },
     "setCutoff": {
       "description": "Set cutoff of FFT",
       "example": "a.setCutoff(cutoff = 2)",
-      "params": [
-        { "name": "cutoff", "default": "2", "description": "Cutoff of FFT" }
-      ],
+      "params": [{ "name": "cutoff", "default": "2", "description": "Cutoff of FFT" }],
       "syntaxType": "method",
       "returnType": "void"
     },
     "setScale": {
       "description": "Set scale of FFT",
       "example": "a.setScale(scale = 10)",
-      "params": [
-        { "name": "scale", "default": "10", "description": "Scale of FFT" }
-      ],
+      "params": [{ "name": "scale", "default": "10", "description": "Scale of FFT" }],
       "syntaxType": "method",
       "returnType": "void"
     },
@@ -769,9 +780,7 @@
     "setBins": {
       "description": "Set number of FFT bins",
       "example": "a.setBins(bins = 4)",
-      "params": [
-        { "name": "bins", "default": "4", "description": "Number of FFT bins" }
-      ],
+      "params": [{ "name": "bins", "default": "4", "description": "Number of FFT bins" }],
       "syntaxType": "method",
       "returnType": "void"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
-import { Elysia } from "elysia";
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { Elysia } from "elysia";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // When running as executable, public dir is relative to executable location
 // When running in dev/build, public dir is relative to project root
-const isExecutable = process.execPath.endsWith("hydractrl.exe") || process.execPath.endsWith("hydractrl");
-const publicDir = isExecutable 
+const isExecutable =
+  process.execPath.endsWith("hydractrl.exe") || process.execPath.endsWith("hydractrl");
+const publicDir = isExecutable
   ? join(dirname(process.execPath), "hydractrl-public")
   : join(__dirname, "..", "public");
 
@@ -23,17 +24,18 @@ const app = new Elysia()
       // Extract the part of the path after "/assets/"
       const assetPath = path.replace(/^\/assets\//, "");
       const filePath = join(publicDir, "assets", assetPath);
-      
+
       // Read file as buffer to handle both text and binary files
       const content = readFileSync(filePath);
-      
+
       // Determine content type based on file extension
       let contentType = "application/octet-stream";
       if (assetPath.endsWith(".js")) contentType = "application/javascript";
       else if (assetPath.endsWith(".css")) contentType = "text/css";
       else if (assetPath.endsWith(".json")) contentType = "application/json";
-      else if (assetPath.endsWith(".png")) contentType = "image/png"; 
-      else if (assetPath.endsWith(".jpg") || assetPath.endsWith(".jpeg")) contentType = "image/jpeg";
+      else if (assetPath.endsWith(".png")) contentType = "image/png";
+      else if (assetPath.endsWith(".jpg") || assetPath.endsWith(".jpeg"))
+        contentType = "image/jpeg";
       else if (assetPath.endsWith(".svg")) contentType = "image/svg+xml";
       else if (assetPath.endsWith(".ico")) contentType = "image/x-icon";
       else if (assetPath.endsWith(".mp4")) contentType = "video/mp4";
@@ -41,7 +43,7 @@ const app = new Elysia()
       else if (assetPath.endsWith(".ogg")) contentType = "video/ogg";
       else if (assetPath.endsWith(".avi")) contentType = "video/x-msvideo";
       else if (assetPath.endsWith(".mov")) contentType = "video/quicktime";
-      
+
       return new Response(content, { headers: { "Content-Type": contentType } });
     } catch (err) {
       console.error(`Failed to serve asset: ${path}`);
@@ -57,18 +59,18 @@ const app = new Elysia()
     if (path === "/" || path.startsWith("/assets/") || path === "/styles.css") {
       return;
     }
-    
+
     try {
       // Remove leading slash and serve from public directory root
       const filePath = join(publicDir, path.slice(1));
       const content = readFileSync(filePath);
-      
+
       // Determine content type based on file extension
       let contentType = "application/octet-stream";
       if (path.endsWith(".js")) contentType = "application/javascript";
       else if (path.endsWith(".css")) contentType = "text/css";
       else if (path.endsWith(".json")) contentType = "application/json";
-      else if (path.endsWith(".png")) contentType = "image/png"; 
+      else if (path.endsWith(".png")) contentType = "image/png";
       else if (path.endsWith(".jpg") || path.endsWith(".jpeg")) contentType = "image/jpeg";
       else if (path.endsWith(".svg")) contentType = "image/svg+xml";
       else if (path.endsWith(".ico")) contentType = "image/x-icon";
@@ -77,7 +79,7 @@ const app = new Elysia()
       else if (path.endsWith(".ogg")) contentType = "video/ogg";
       else if (path.endsWith(".avi")) contentType = "video/x-msvideo";
       else if (path.endsWith(".mov")) contentType = "video/quicktime";
-      
+
       return new Response(content, { headers: { "Content-Type": contentType } });
     } catch (err) {
       console.error(`Failed to serve file: ${path}`);

--- a/src/utils/CodeMirrorEditor.js
+++ b/src/utils/CodeMirrorEditor.js
@@ -3,16 +3,16 @@
  * Uses CodeMirror 6 with JavaScript mode for syntax highlighting
  */
 
-import { EditorState, Compartment } from "@codemirror/state";
-import { EditorView, keymap, lineNumbers, highlightActiveLineGutter } from "@codemirror/view";
-import { history, defaultKeymap, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { CompletionContext, autocompletion, startCompletion } from "@codemirror/autocomplete";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
+import { Compartment, EditorState } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
+import { EditorView, highlightActiveLineGutter, keymap, lineNumbers } from "@codemirror/view";
 import { dracula } from "@uiw/codemirror-theme-dracula";
-import { monokai } from "@uiw/codemirror-theme-monokai";
 import { eclipse } from "@uiw/codemirror-theme-eclipse";
+import { monokai } from "@uiw/codemirror-theme-monokai";
 import { solarizedDark } from "@uiw/codemirror-theme-solarized";
-import { autocompletion, CompletionContext, startCompletion } from "@codemirror/autocomplete";
 import hydraData from "../data/hydra-functions.json" assert { type: "json" };
 
 // Language compartment for JavaScript with Hydra extensions
@@ -61,12 +61,12 @@ const hydraFunctions = Object.fromEntries(
     name,
     {
       description: func.description,
-      params: func.params.map(param => 
-        param.default ? `${param.name} = ${param.default}` : param.name
+      params: func.params.map((param) =>
+        param.default ? `${param.name} = ${param.default}` : param.name,
       ),
-      example: func.example
-    }
-  ])
+      example: func.example,
+    },
+  ]),
 );
 
 // Add some P5 related functions that aren't in the JSON data
@@ -90,7 +90,7 @@ const p5Functions = {
   mouseMoved: {
     description: "P5 mouseMoved event function",
     params: [],
-  }
+  },
 };
 
 // Merge hydra functions with P5 functions
@@ -107,19 +107,17 @@ const hydraKeywords = Object.keys(hydraFunctions);
 function hydraCompletions(context) {
   // Check for function names
   const functionMatch = context.matchBefore(/\w*$/);
-  if (functionMatch.from == functionMatch.to && !context.explicit) {
+  if (functionMatch.from === functionMatch.to && !context.explicit) {
     return null;
   }
 
   // Generate completions for Hydra function names
   const matchText = functionMatch.text.toLowerCase();
   const completions = Object.keys(hydraFunctions)
-    .filter(keyword => keyword.toLowerCase().startsWith(matchText))
-    .map(keyword => {
+    .filter((keyword) => keyword.toLowerCase().startsWith(matchText))
+    .map((keyword) => {
       const funcData = hydraFunctions[keyword];
-      const paramInfo = funcData.params.length > 0
-        ? `(${funcData.params.join(", ")})`
-        : "()";
+      const paramInfo = funcData.params.length > 0 ? `(${funcData.params.join(", ")})` : "()";
 
       return {
         label: keyword,
@@ -127,31 +125,36 @@ function hydraCompletions(context) {
         detail: paramInfo,
         info: `${funcData.description}`,
         apply: keyword + "(", // Add opening parenthesis for function call
-        boost: 1
+        boost: 1,
       };
     });
 
   // Check for method chaining (like .color(), .rotate(), etc.)
   const methodMatch = context.matchBefore(/\.\w*$/);
-  if (methodMatch && methodMatch.from != methodMatch.to) {
+  if (methodMatch && methodMatch.from !== methodMatch.to) {
     const methodText = methodMatch.text.substring(1).toLowerCase(); // Remove the dot
     const methodCompletions = Object.keys(hydraFunctions)
-      .filter(keyword => {
+      .filter((keyword) => {
         // Use syntaxType from JSON data if available, otherwise use legacy exclusion list
         const funcData = hydraData.functions[keyword];
-        const isMethodOrChainable = funcData ? 
-          (funcData.syntaxType === "method" || funcData.syntaxType === "property") :
-          // Legacy fallback: exclude known source functions
-          !(keyword === "osc" || keyword === "noise" || keyword === "voronoi" || 
-            keyword === "shape" || keyword === "gradient" || keyword === "src" || keyword === "solid");
-        
+        const isMethodOrChainable = funcData
+          ? funcData.syntaxType === "method" || funcData.syntaxType === "property"
+          : // Legacy fallback: exclude known source functions
+            !(
+              keyword === "osc" ||
+              keyword === "noise" ||
+              keyword === "voronoi" ||
+              keyword === "shape" ||
+              keyword === "gradient" ||
+              keyword === "src" ||
+              keyword === "solid"
+            );
+
         return isMethodOrChainable && keyword.toLowerCase().startsWith(methodText);
       })
-      .map(keyword => {
+      .map((keyword) => {
         const funcData = hydraFunctions[keyword];
-        const paramInfo = funcData.params.length > 0
-          ? `(${funcData.params.join(", ")})`
-          : "()";
+        const paramInfo = funcData.params.length > 0 ? `(${funcData.params.join(", ")})` : "()";
 
         return {
           label: keyword,
@@ -159,7 +162,7 @@ function hydraCompletions(context) {
           detail: paramInfo,
           info: `${funcData.description} \n\nExample: ${funcData.example} `,
           apply: keyword + "(", // Add opening parenthesis for function call
-          boost: 1
+          boost: 1,
         };
       });
 
@@ -167,7 +170,7 @@ function hydraCompletions(context) {
       return {
         from: methodMatch.from + 1, // +1 to account for the dot
         options: methodCompletions,
-        validFor: /^\w*$/
+        validFor: /^\w*$/,
       };
     }
   }
@@ -177,7 +180,7 @@ function hydraCompletions(context) {
     return {
       from: functionMatch.from,
       options: completions,
-      validFor: /^\w*$/
+      validFor: /^\w*$/,
     };
   }
 
@@ -225,8 +228,8 @@ export function createCodeMirrorEditor(container, initialCode = "") {
       // Add Ctrl+Space for manual trigger of completion
       key: "Ctrl-Space",
       mac: "Cmd-Space",
-      run: startCompletion
-    }
+      run: startCompletion,
+    },
   ]);
 
   // Function to get the appropriate theme based on body class
@@ -239,7 +242,7 @@ export function createCodeMirrorEditor(container, initialCode = "") {
       }
     }
     // Default to the default theme if no matching class is found
-    return themeMapping["default"];
+    return themeMapping.default;
   }
 
   // Create initial editor state
@@ -264,8 +267,8 @@ export function createCodeMirrorEditor(container, initialCode = "") {
         activateOnTyping: true,
         defaultKeymap: true,
         icons: true,
-        closeOnBlur: true
-      })
+        closeOnBlur: true,
+      }),
     ],
   });
 

--- a/src/utils/PanelStorage.js
+++ b/src/utils/PanelStorage.js
@@ -90,12 +90,12 @@ export function setupPanelPersistence(element, panelId, defaultPosition = {}, op
   if (options.skipSizeRestore) {
     // Use size from options, not from saved position
     if (options.width !== undefined) {
-      element.style.width = typeof options.width === 'number' ? 
-        options.width + "px" : options.width;
+      element.style.width =
+        typeof options.width === "number" ? options.width + "px" : options.width;
     }
     if (options.height !== undefined) {
-      element.style.height = typeof options.height === 'number' ? 
-        options.height + "px" : options.height;
+      element.style.height =
+        typeof options.height === "number" ? options.height + "px" : options.height;
     }
   } else {
     // Use saved size if available
@@ -120,8 +120,8 @@ export function setupPanelPersistence(element, panelId, defaultPosition = {}, op
   // Function to save current position and optionally size
   function savePosition() {
     const currentPosition = {
-      left: parseInt(element.style.left || "0"),
-      top: parseInt(element.style.top || "0")
+      left: Number.parseInt(element.style.left || "0"),
+      top: Number.parseInt(element.style.top || "0"),
     };
 
     // Only save size if not using skipSizeRestore
@@ -143,14 +143,14 @@ export function setupPanelPersistence(element, panelId, defaultPosition = {}, op
  * @returns {function} An enhanced makeDraggable function
  */
 export function enhanceMakeDraggable(makeDraggable) {
-  return function (element, handle, panelId) {
+  return (element, handle, panelId) => {
     // Keep track of the persistence controller
     let persistence = null;
 
     if (panelId) {
       const defaultPosition = {
-        left: parseInt(element.style.left || "20"),
-        top: parseInt(element.style.top || "20"),
+        left: Number.parseInt(element.style.left || "20"),
+        top: Number.parseInt(element.style.top || "20"),
         width: element.offsetWidth || "auto",
         height: element.offsetHeight || "auto",
       };

--- a/src/utils/XYPhysics.js
+++ b/src/utils/XYPhysics.js
@@ -15,14 +15,14 @@ export class XYPhysics {
     this.vy = 0;
 
     // Position history for velocity calculation
-    this.historySize = options.historySize ?? 5;  // Number of points to keep
+    this.historySize = options.historySize ?? 5; // Number of points to keep
     this.xHistory = [];
     this.yHistory = [];
     this.timeHistory = [];
 
     // Physics parameters (with defaults)
-    this.friction = options.friction ?? 0;  // Friction (0-1), higher means more friction
-    this.bounce = options.bounce ?? 1;     // Bounciness (0-1)
+    this.friction = options.friction ?? 0; // Friction (0-1), higher means more friction
+    this.bounce = options.bounce ?? 1; // Bounciness (0-1)
     this.velocityLimit = options.velocityLimit ?? 2000; // Max velocity to prevent instability
 
     // Animation frame handling
@@ -37,7 +37,7 @@ export class XYPhysics {
     const dt = deltaTime / 1000;
 
     // Apply friction (1 - friction to invert the behavior)
-    const frictionFactor = Math.pow(1 - this.friction, dt * 60); // Scale friction by framerate
+    const frictionFactor = (1 - this.friction) ** (dt * 60); // Scale friction by framerate
     this.vx *= frictionFactor;
     this.vy *= frictionFactor;
 


### PR DESCRIPTION
## Summary

This PR improves reliability/stability and restructures the client around a small **plugin system** so new features can be added without touching the core. Two open issues get concrete fixes (#7, partial #5, diagnostics for #1).

### Reliability & bug fixes
- **Issue #7**: the UI toggle now matches the *physical* `` ` `` key (`e.code === "Backquote"`), so it works on international keyboard layouts — and **Esc always brings back a hidden UI**, so there's a layout-independent way to recover.
- Fixed `applyUiVisibility` hiding the stats panel twice and never hiding the slots panel (wrong variable); all visibility handling is now a single `setUiVisibility()`.
- Quota-safe storage: new writes go through a wrapper that never throws (`QuotaExceededError` from thumbnails could previously escape `try/catch` in async callbacks), and a failed `init()` now shows a visible error instead of a silent black screen.
- Removed checks on the non-existent `e.optKey`.
- Lint baseline cleaned up: `bun run lint` went from 134 errors to clean (mechanical Biome fixes + stylistic rules disabled in `biome.json`).

### Plugin system
- New `src/client/core/`: **EventBus** (pub/sub with per-listener error isolation), **PluginHost** (lifecycle with error isolation — a plugin that throws is disabled and logged, never fatal), **Storage** (quota-safe localStorage wrapper), **notify** (unified toasts replacing six duplicated blocks).
- Plugins receive a stable context (`hydra`, `editor`, `runCode`, `events`, `storage`, `notify`, `getPanels`), and can be registered at runtime via `window.hydractrl.registerPlugin(...)`.
- Documented in [docs/PLUGINS.md](https://github.com/dxviie/HYDRACTRL/blob/claude/project-reliability-plugins-vgajt2/docs/PLUGINS.md).

### Built-in plugins (proof of the system)
- **URL sketch sharing** (issue #5): `Alt/⌥ + U` copies a `#sketch=<base64url>` link; opening one loads and runs the sketch **without touching the recipient's saved banks** (slots panel gained a `keepEditorContent` option so slot 0 doesn't clobber the URL sketch at startup).
- **Audio watchdog** (issue #1): detects `a.fft` flatlining after activity, logs a timestamped diagnostic dump, and auto-resumes suspended AudioContexts (the most common cause of silent FFT cutouts), with a retry on the next user gesture.

### Tests & CI
- 46 unit tests (`bun test`) covering the event bus, plugin host, storage wrapper, URL codec, and FFT flatline detection — the repo previously had none.
- GitHub Actions workflow running lint, tests, and build on every push/PR.

### Docs
- GitHub Page (`docs/index.html`): feature cards for URL sharing and the plugin system, refreshed shortcuts table, links to the plugin docs.
- README fully refreshed: features, shortcuts, dev commands, plugin docs link, credits/license.

## Test plan
- [x] `bun run lint`, `bun test` (46 pass), `bun run build` all green
- [x] End-to-end in headless Chromium: app boots with both plugins active; `Ctrl+Backquote` hides UI; `Esc` restores it; `copyLink` produces a working share URL; a `#sketch=` URL loads into the editor and is not persisted; no unexpected console errors
- [ ] Manual smoke test on a real setup (MIDI device, audio input) recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01415jbZewXCqWSdPME2kWqM

---
_Generated by [Claude Code](https://claude.ai/code/session_01415jbZewXCqWSdPME2kWqM)_